### PR TITLE
Modified setup.py, removed xmlwitch dev version dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(name=project_name,
     author_email='alexey.diyan@gmail.com',
     url='http://github.com/diyan/pywinrm/',
     packages=['winrm', 'winrm.http'],
-    install_requires=['xmlwitch==dev', 'isodate'],
+    install_requires=['xmlwitch', 'isodate'],
     dependency_links=['https://github.com/diyan/xmlwitch/tarball/master#egg=xmlwitch-dev'],
     cmdclass={
         'bootstrap_env': BootstrapEnvironmentCommand  }


### PR DESCRIPTION
I could not get the install to work with the xmlwitch==dev in the setup.py. 

```
source in ./build/xmlwitch has the version 0.2.1, which does not match the requirement xmlwitch==dev (from pywinrm==0.0.1)
```

with the the version dependency, it installs
