### PR TITLE
fixed error when using ssl transport with basic auth and without a cert file

### DIFF
--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -127,7 +127,7 @@ class HttpSSL(HttpPlaintext):
 
     def _setup_opener(self):
         if not self._cert_pem:
-            super(HttpSSL, self)._setup_opener(message)
+            super(HttpSSL, self)._setup_opener()
         else:
             opener = build_opener(HTTPSClientAuthHandler(self._cert_pem, self._cert_key_pem))
             install_opener(opener)


### PR DESCRIPTION
When attempting to use the ssl transport without the new cert feature (basic auth over ssl), the following error occurs:

```
File "/devel/lib/pywinrm/winrm/transport.py", line 130, in _setup_opener
    super(HttpSSL, self)._setup_opener(message)
NameError: global name 'message' is not defined
```

This patch fixes this error and has been tested for SSL using basic auth. 
