### PR TITLE
Retry receive instead of raising exception for long-running command

### DIFF
--- a/winrm/tests/test_integration_protocol.py
+++ b/winrm/tests/test_integration_protocol.py
@@ -42,6 +42,20 @@ def test_get_command_output(protocol_real):
     protocol_real.close_shell(shell_id)
 
 
+def test_run_command_taking_more_than_60_seconds(protocol_real):
+    shell_id = protocol_real.open_shell()
+    command_id = protocol_real.run_command(shell_id, 'PowerShell -Command Start-Sleep -s 75')
+    assert re.match('^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$', command_id)
+    std_out, std_err, status_code = protocol_real.get_command_output(
+        shell_id, command_id)
+
+    assert status_code == 0
+    assert len(std_err) == 0
+
+    protocol_real.cleanup_command(shell_id, command_id)
+    protocol_real.close_shell(shell_id)
+
+
 @xfail()
 def test_set_timeout(protocol_real):
     raise NotImplementedError()

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -84,6 +84,11 @@ class HttpPlaintext(HttpTransport):
             #return doc
             #return doc
         except HTTPError as ex:
+            response_text = ex.read()
+            # Per http://msdn.microsoft.com/en-us/library/cc251676.aspx rule 3,
+            # should handle this 500 error and retry receiving command output.
+            if 'http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive' in message and 'Code="2150858793"' in response_text:
+                return response_text
             error_message = 'Bad HTTP response returned from server. Code {0}'.format(ex.code)
             if ex.msg:
                 error_message += ', {0}'.format(ex.msg)
@@ -200,6 +205,11 @@ class HttpKerberos(HttpTransport):
             response_text = response.read()
             return response_text
         except HTTPError as ex:
+            response_text = ex.read()
+            # Per http://msdn.microsoft.com/en-us/library/cc251676.aspx rule 3,
+            # should handle this 500 error and retry receiving command output.
+            if 'http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive' in message and 'Code="2150858793"' in response_text:
+                return response_text
             #if ex.code == 401 and ex.headers['WWW-Authenticate'] == 'Negotiate, Basic realm="WSMAN"':
             error_message = 'Kerberos-based authentication was failed. Code {0}'.format(ex.code)
             if ex.msg:


### PR DESCRIPTION
This change fixes an exception raised when a command takes longer than 60 seconds, and the receive operation times out (due to the default OperationTimeout of PT60S).  Per the MS docs (http://msdn.microsoft.com/en-us/library/cc251676.aspx) we handle this particular fault (with 500 status code) and retry.

I would be open to another way of implementing it (i.e. actually parsing the XML returned), but this way is simple and seems to work for me.
