### PR TITLE
Removed debug print statement

### DIFF
--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -52,7 +52,6 @@ class Session(object):
         if msg.startswith("#< CLIXML\r\n"):
             # for proper xml, we need to remove the CLIXML part (the first line)
             msg_xml = msg[11:]
-            print(">%s<" % msg_xml)
             try:
                 # remove the namespaces from the xml for easier processing
                 msg_xml = self.strip_namespace(msg_xml)


### PR DESCRIPTION
Also I wonder if you would be open to use Python's "logging" facility instead of the occasional "print", so you could leave debug lines without affecting the code when is not run in debug mode.

Thanks for pywinrm, it is very useful!
