### PR TITLE
update __init__ for Session to get argbitrary keywords for use with ssl

### DIFF
--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -18,11 +18,11 @@ class Response(object):
 
 class Session(object):
     # TODO implement context manager methods
-    def __init__(self, target, auth, transport='plaintext'):
+    def __init__(self, target, auth, **kwargs):
         username, password = auth
-        self.url = self._build_url(target, transport)
-        self.protocol = Protocol(self.url, transport=transport,
-                                 username=username, password=password)
+        self.url = self._build_url(target, kwargs.get('transport', 'plaintext'))
+        self.protocol = Protocol(self.url,
+                                 username=username, password=password, **kwargs)
 
     def run_cmd(self, command, args=()):
         # TODO optimize perf. Do not call open/close shell every time


### PR DESCRIPTION
hi.
I've noticed I cannot access initialization of self.protocol in Session(), if I want to pass various ssl related params (certificates), so to be able to do this - I'm adding **kwargs.
I could have explicitly specified what protocol params I want to pass, but this would be of lower future compatiblity.
This seems to break nothing and seems to not require any additional tests.
Tell me what you think.
