### PR TITLE
Adding setup.cfg to configure command for rpm build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_rpm]
+requires = python-xmltodict python-isodate


### PR DESCRIPTION
In order to build rpm for this library, it requires adding dependency to build proper rpm package.