### PR TITLE
Add means to set timeouts

### DIFF
--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -12,7 +12,7 @@ class Protocol(object):
     are a few helper classes, but pretty much everything comes through here
     first.
     """
-    DEFAULT_TIMEOUT = 'PT60S'
+    DEFAULT_TIMEOUT = 60
     DEFAULT_MAX_ENV_SIZE = 153600
     DEFAULT_LOCALE = 'en-US'
 
@@ -32,7 +32,7 @@ class Protocol(object):
         @param string cert_key_pem: client authentication certificate key file path in PEM format  # NOQA
         """
         self.endpoint = endpoint
-        self.timeout = Protocol.DEFAULT_TIMEOUT
+        self.set_timeout(self.DEFAULT_TIMEOUT)
         self.max_env_sz = Protocol.DEFAULT_MAX_ENV_SIZE
         self.locale = Protocol.DEFAULT_LOCALE
         if transport == 'plaintext':
@@ -57,7 +57,7 @@ class Protocol(object):
          It will be converted to an ISO8601 format.
         """
         # in original library there is an alias - op_timeout method
-        return duration_isoformat(timedelta(seconds))
+        self.timeout = duration_isoformat(timedelta(seconds=seconds))
 
     def open_shell(self, i_stream='stdin', o_stream='stdout stderr',
                    working_directory=None, env_vars=None, noprofile=False,
@@ -164,7 +164,7 @@ class Protocol(object):
                 },
                 # TODO: research this a bit http://msdn.microsoft.com/en-us/library/cc251561(v=PROT.13).aspx  # NOQA
                 # 'cfg:MaxTimeoutms': 600
-                'w:OperationTimeout': 'PT60S',
+                'w:OperationTimeout': self.timeout,
                 'w:ResourceURI': {
                     '@mustUnderstand': 'true',
                     '#text': resource_uri

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -27,13 +27,18 @@ else:
 
 
 class HttpTransport(object):
+    # Set this to an unreasonable amount for now because WinRM has timeouts
+    DEFAULT_TIMEOUT = 3600
+
     def __init__(self, endpoint, username, password):
         self.endpoint = endpoint
         self.username = username
         self.password = password
         self.user_agent = 'Python WinRM client'
-        # Set this to an unreasonable amount for now because WinRM has timeouts
-        self.timeout = 3600
+        self.timeout = self.DEFAULT_TIMEOUT
+
+    def set_timeout(self, timeout):
+        self.timeout = timeout
 
     def basic_auth_only(self):
         # here we should remove handler for any authentication handlers other
@@ -121,8 +126,8 @@ class HTTPSClientAuthHandler(HTTPSHandler):
     def https_open(self, req):
         return self.do_open(self.getConnection, req)
 
-    def getConnection(self, host, timeout=300):
-        return HTTPSConnection(host, key_file=self.key, cert_file=self.cert)
+    def getConnection(self, host, timeout):
+        return HTTPSConnection(host, key_file=self.key, cert_file=self.cert, timeout=timeout)
 
 
 class HttpSSL(HttpPlaintext):


### PR DESCRIPTION
At the moment, there is a method which should be able to set
the OperationTimeout value. In fact, this method simply returns,
while the OperationTimeout is hardcoded.

This patch fixes this as well as the transport timeout.