### PR TITLE
Fixed string issue on Python 3.4.1 where strings are incorrectly concatenated as binary representations

### DIFF
--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -339,9 +339,9 @@ class Protocol(object):
             if not stream_node.text:
                 continue
             if stream_node.attrib['Name'] == 'stdout':
-                stdout += str(base64.b64decode(stream_node.text.encode('ascii')))
+                stdout += base64.b64decode(stream_node.text.encode('ascii')).decode('utf-8')
             elif stream_node.attrib['Name'] == 'stderr':
-                stderr += str(base64.b64decode(stream_node.text.encode('ascii')))
+                stderr += base64.b64decode(stream_node.text.encode('ascii')).decode('utf-8')
 
         # We may need to get additional output if the stream has not finished.
         # The CommandState will change from Running to Done like so:


### PR DESCRIPTION
When running a command using the example provided on the github project page, output was formatted as follows -

*Example*

b' Volume in drive C is OSDisk\r\n'b' Volume Serial Number is CE5D-2D9B\r\n\r\n Directory of C:\\Users\\winrmtest\r\n\r\n03/08/2015  12:53    <DIR>          .\r\n03/08/2015  12:53    <DIR>          ..\r\n14/07/2009  03:34    <DIR>          Desktop\r\n03/08/2015  12:53    <DIR>          Documents\r\n14/07/2009  03:34    <DIR>          Downloads\r\n14/07/2009  03:34    <DIR>          Favorites\r\n14/07/2009  03:34    <DIR>          Links\r\n14/07/2009  03:34    <DIR>          Music\r\n14/07/2009  03:34    <DIR>          Pictures\r\n14/07/2009  03:34    <DIR>          Saved Games\r\n14/07/2009  03:34    <DIR>          Videos\r\n               0 File(s)              0 bytes\r\n              11 Dir(s)  42,674,880,512 bytes free\r\n'

For longer outputs, there would be multiple b' entries within the context owing to the string append that takes place.

I made the following in protocol.py which seem to resolve the issue in question -

*Before:*
`stdout += str(base64.b64decode(stream_node.text.encode('ascii')))`

*After:*
`stdout += base64.b64decode(stream_node.text.encode('ascii')).decode('utf-8')`

*Example output after changes:*

 Volume in drive C is OSDisk
 Volume Serial Number is CE5D-2D9B

 Directory of C:\Users\winrmtest

03/08/2015  12:53    <DIR>          .
03/08/2015  12:53    <DIR>          ..
14/07/2009  03:34    <DIR>          Desktop
03/08/2015  12:53    <DIR>          Documents
14/07/2009  03:34    <DIR>          Downloads
14/07/2009  03:34    <DIR>          Favorites
14/07/2009  03:34    <DIR>          Links
14/07/2009  03:34    <DIR>          Music
14/07/2009  03:34    <DIR>          Pictures
14/07/2009  03:34    <DIR>          Saved Games
14/07/2009  03:34    <DIR>          Videos
               0 File(s)              0 bytes
              11 Dir(s)  42,674,782,208 bytes free