### PR TITLE
Fixed bug in transport.py

### DIFF
--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -202,7 +202,7 @@ class HttpKerberos(HttpTransport):
         @param string keytab: the path to a keytab file if you are using one
         """
         if not HAVE_KERBEROS:
-            raise WinRMTransportError('kerberos is not installed')
+            raise WinRMTransportError('kerberos', 'kerberos is not installed')
 
         super(HttpKerberos, self).__init__(endpoint, None, None)
         self.krb_service = '{0}@{1}'.format(


### PR DESCRIPTION
WinRMTransportError was called with only one argument instead of two, raising the type error:
TypeError: __init__() takes exactly 3 arguments (2 given)