### PR TITLE
reduce latency by always forcing basic auth header

### DIFF
--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -25,6 +25,19 @@ else:
     from urllib.parse import urlparse
     from http.client import HTTPSConnection
 
+# the built-in basic auth handler waits for a 401 before sending creds, doubling all the requests
+class ForcedBasicAuthHandler(HTTPBasicAuthHandler):
+    def http_request(self, req):
+        url = req.get_full_url()
+        user, password = self.passwd.find_user_password(None, url)
+        if password:
+            base64_user_pass = ('%s:%s' % (user, password)).encode('base64').strip()
+            auth_header_value = 'Basic %s' % base64_user_pass
+            req.add_unredirected_header(self.auth_header, auth_header_value)
+        return req
+
+    https_request = http_request
+
 
 class HttpTransport(object):
     def __init__(self, endpoint, username, password):
@@ -68,7 +81,7 @@ class HttpPlaintext(HttpTransport):
         password_manager = HTTPPasswordMgrWithDefaultRealm()
         password_manager.add_password(
             None, self.endpoint, self.username, self.password)
-        auth_manager = HTTPBasicAuthHandler(password_manager)
+        auth_manager = ForcedBasicAuthHandler(password_manager)
         opener = build_opener(auth_manager)
         install_opener(opener)
 


### PR DESCRIPTION
Default urllib2 basic auth behavior is RFC-pedantic, only sending Basic auth on receipt of a 401. This vastly increases latency, since we have to send all requests twice. This patch forces the basic auth header onto the initial request.