### PR TITLE
Expanding the exception classes to include WinRM responses.

### DIFF
--- a/winrm/exceptions.py
+++ b/winrm/exceptions.py
@@ -23,9 +23,33 @@ class WinRMError(Exception):
     def dict_response(self):
         try:
             return xmltodict.parse(self.winrm_response)
-        except xmltodict.expat.ExpatError:
+        except (xmltodict.expat.ExpatError, TypeError):
             pass
 
+        return None
+
+    def fault_code(self):
+        if isinstance(self.dict_response(), dict):
+            try:
+                return self.dict_response()['s:Envelope']['s:Body']['s:Fault']['s:Code']['s:Value']
+            except (KeyError, AttributeError, TypeError):
+                pass
+        return None
+
+    def fault_subcode(self):
+        if isinstance(self.dict_response(), dict):
+            try:
+                return self.dict_response()['s:Envelope']['s:Body']['s:Fault']['s:Code']['s:Subcode']['s:Value']
+            except (KeyError, AttributeError, TypeError):
+                pass
+        return None
+
+    def fault_reason(self):
+        if isinstance(self.dict_response(), dict):
+            try:
+                return self.dict_response()['s:Envelope']['s:Body']['s:Fault']['s:Reason']['s:Text']['#text']
+            except (KeyError, AttributeError, TypeError):
+                pass
         return None
 
 

--- a/winrm/exceptions.py
+++ b/winrm/exceptions.py
@@ -1,15 +1,39 @@
 from __future__ import unicode_literals
+import xmltodict
 
 
 class WinRMError(Exception):
     """"Generic WinRM error"""
-    code = 500
 
-class WinRMTransportError(Exception):
+    code = 500
+    winrm_response = None
+
+    def __init__(self, *args, **kwargs):
+        try:
+            self.winrm_response = kwargs.pop('winrm_resposne')
+        except KeyError:
+            pass
+
+        try:
+            self.code = kwargs.pop('code')
+        except KeyError:
+            pass
+        super(WinRMError, self).__init__(*args, **kwargs)
+
+    def dict_response(self):
+        try:
+            return xmltodict.parse(self.winrm_response)
+        except xmltodict.expat.ExpatError:
+            pass
+
+        return None
+
+
+class WinRMTransportError(WinRMError):
     """WinRM errors specific to transport-level problems (unexpcted HTTP error codes, etc)"""
     code = 500
 
-class WinRMOperationTimeoutError(Exception):
+class WinRMOperationTimeoutError(WinRMError):
     """
     Raised when a WinRM-level operation timeout (not a connection-level timeout) has occurred. This is
     considered a normal error that should be retried transparently by the client when waiting for output from

--- a/winrm/tests/conftest.py
+++ b/winrm/tests/conftest.py
@@ -404,7 +404,4 @@ class MockRequests(object):
 
 @fixture(scope='module')
 def mocked_requests():
-    req_mock = MockRequests()
-    req_mock.start_mock()
-    yield req_mock
-    req_mock.stop_mock()
+    return MockRequests()

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -6,7 +6,7 @@ def test_transport_send_success(mocked_requests):
     # Return a 200 and make sure the text is returned.
     mocked_requests.start_mock()
     mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=200,
-                                                                                          text='success')
+                                                                                          text=b'success')
     test_transport = transport.Transport('testendpoint', username='fakeusername', password='fakepassword',
                                          auth_method='basic')
     result = test_transport.send_message('test')
@@ -18,7 +18,7 @@ def test_transport_send_401(mocked_requests):
     # Return a 401 and make a InvalidCredentialsError exception is raised
     mocked_requests.start_mock()
     mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=401,
-                                                                                          text='auth failure')
+                                                                                          text=b'auth failure')
     expected_exception = None
     try:
         test_transport = transport.Transport('testendpoint', username='fakeusername', password='fakepassword',
@@ -35,7 +35,7 @@ def test_transport_send_operation_timeout(mocked_requests):
     # Make sure we can raise an Operation Timeout exception properly
     mocked_requests.start_mock()
     mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=500,
-                                                                                          text='Code="2150858793"')
+                                                                                          text=b'Code="2150858793"')
     expected_exception = None
     try:
         test_transport = transport.Transport('testendpoint', username='fakeusername', password='fakepassword',

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -1,0 +1,76 @@
+from winrm import transport
+import mock
+
+
+def test_transport_send_success(mocked_requests):
+    # Return a 200 and make sure the text is returned.
+    mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=200,
+                                                                                          text='success')
+    test_transport = transport.Transport('testendpoint', username='fakeusername', password='fakepassword',
+                                         auth_method='basic')
+    result = test_transport.send_message('test')
+    assert result == 'success'
+
+
+def test_transport_send_401(mocked_requests):
+    # Return a 200 and make sure the text is returned.
+    mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=401,
+                                                                                          text='auth failure')
+    expected_exception = None
+    try:
+        test_transport = transport.Transport('testendpoint', username='fakeusername', password='fakepassword',
+                                             auth_method='basic')
+        result = test_transport.send_message('test')
+    except transport.InvalidCredentialsError as expected_exception:
+        pass
+
+    assert isinstance(expected_exception, transport.InvalidCredentialsError)
+
+
+def test_transport_send_operation_timeout(mocked_requests):
+    # Return a 200 and make sure the text is returned.
+    mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=500,
+                                                                                          text='Code="2150858793"')
+    expected_exception = None
+    try:
+        test_transport = transport.Transport('testendpoint', username='fakeusername', password='fakepassword',
+                                             auth_method='basic')
+        result = test_transport.send_message('asdfhttp://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receiveasdf')
+    except transport.WinRMOperationTimeoutError as expected_exception:
+        pass
+
+    assert isinstance(expected_exception, transport.WinRMOperationTimeoutError)
+
+
+def test_transport_send_random_error(mocked_requests):
+    mocked_requests.set_closed_session_error()
+    expected_exception = None
+    try:
+        test_transport = transport.Transport('testendpoint', username='fakeusername', password='fakepassword',
+                                             auth_method='basic')
+        result = test_transport.send_message('fake_message')
+    except transport.WinRMTransportError as expected_exception:
+        pass
+
+    assert isinstance(expected_exception, transport.WinRMTransportError)
+    assert expected_exception.fault_code() == "s:Sender"
+    assert expected_exception.fault_subcode() == "w:InvalidSelectors"
+    assert 'service cannot process the request' in expected_exception.fault_reason()
+
+
+def test_transport_send_nocontent(mocked_requests):
+    # Return a 200 and make sure the text is returned.
+    mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=500, text=None)
+    expected_exception = None
+    try:
+        test_transport = transport.Transport('testendpoint', username='fakeusername', password='fakepassword',
+                                             auth_method='basic')
+        result = test_transport.send_message('asdfhttp://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receiveasdf')
+    except transport.WinRMTransportError as expected_exception:
+        pass
+
+    assert isinstance(expected_exception, transport.WinRMTransportError)
+    assert expected_exception.fault_code() is None
+    assert expected_exception.fault_subcode() is None
+    assert expected_exception.fault_reason() is None
+    assert expected_exception.dict_response() is None

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -4,16 +4,19 @@ import mock
 
 def test_transport_send_success(mocked_requests):
     # Return a 200 and make sure the text is returned.
+    mocked_requests.start_mock()
     mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=200,
                                                                                           text='success')
     test_transport = transport.Transport('testendpoint', username='fakeusername', password='fakepassword',
                                          auth_method='basic')
     result = test_transport.send_message('test')
     assert result == 'success'
+    mocked_requests.stop_mock()
 
 
 def test_transport_send_401(mocked_requests):
-    # Return a 200 and make sure the text is returned.
+    # Return a 401 and make a InvalidCredentialsError exception is raised
+    mocked_requests.start_mock()
     mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=401,
                                                                                           text='auth failure')
     expected_exception = None
@@ -25,10 +28,12 @@ def test_transport_send_401(mocked_requests):
         pass
 
     assert isinstance(expected_exception, transport.InvalidCredentialsError)
+    mocked_requests.stop_mock()
 
 
 def test_transport_send_operation_timeout(mocked_requests):
-    # Return a 200 and make sure the text is returned.
+    # Make sure we can raise an Operation Timeout exception properly
+    mocked_requests.start_mock()
     mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=500,
                                                                                           text='Code="2150858793"')
     expected_exception = None
@@ -40,9 +45,12 @@ def test_transport_send_operation_timeout(mocked_requests):
         pass
 
     assert isinstance(expected_exception, transport.WinRMOperationTimeoutError)
+    mocked_requests.stop_mock()
 
 
 def test_transport_send_random_error(mocked_requests):
+    # With a random error returned, make sure we are able to view the details of the error if needed.
+    mocked_requests.start_mock()
     mocked_requests.set_closed_session_error()
     expected_exception = None
     try:
@@ -56,10 +64,12 @@ def test_transport_send_random_error(mocked_requests):
     assert expected_exception.fault_code() == "s:Sender"
     assert expected_exception.fault_subcode() == "w:InvalidSelectors"
     assert 'service cannot process the request' in expected_exception.fault_reason()
+    mocked_requests.stop_mock()
 
 
 def test_transport_send_nocontent(mocked_requests):
-    # Return a 200 and make sure the text is returned.
+    # Test a random error with no content.
+    mocked_requests.start_mock()
     mocked_requests.session_send_mock.return_value = mocked_requests.get_request_response(status_code=500, text=None)
     expected_exception = None
     try:
@@ -74,3 +84,4 @@ def test_transport_send_nocontent(mocked_requests):
     assert expected_exception.fault_subcode() is None
     assert expected_exception.fault_reason() is None
     assert expected_exception.dict_response() is None
+    mocked_requests.stop_mock()

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -176,7 +176,8 @@ class Transport(object):
             return response_text
         except requests.HTTPError as ex:
             if ex.response.status_code == 401:
-                raise InvalidCredentialsError("the specified credentials were rejected by the server")
+                raise InvalidCredentialsError("the specified credentials were rejected by the server",
+                                              winrm_resposne=ex.response.content, code=ex.response.status_code)
             if ex.response.content:
                 response_text = ex.response.content
             else:
@@ -184,8 +185,9 @@ class Transport(object):
             # Per http://msdn.microsoft.com/en-us/library/cc251676.aspx rule 3,
             # should handle this 500 error and retry receiving command output.
             if b'http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive' in message and b'Code="2150858793"' in response_text:
-                raise WinRMOperationTimeoutError()
+                raise WinRMOperationTimeoutError(winrm_resposne=ex.response.content, code=ex.response.status_code)
 
             error_message = 'Bad HTTP response returned from server. Code {0}'.format(ex.response.status_code)
 
-            raise WinRMTransportError('http', error_message)
+            raise WinRMTransportError('http', error_message, winrm_resposne=ex.response.content,
+                                      code=ex.response.status_code)


### PR DESCRIPTION
Currently the WinRM exceptions are reduced to a couple of Exception types, and the true response code is returned as part of the string message.

This change includes the actual server response back if the application requires that information, along with methods for displaying the fault codes and messages.