### PR TITLE
Allow for disconnect from server on shell close.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `proxy` support where it can be defined within the application, with the ability to specify the proxy within the application
 - Fix for shell not setting all environment variables.
 - Fix session clixml encoding on Python 3
+- `Protocol.close_shell(shell_id)` will now close the session(and TCP connections) to the Windows machine. `close_session` option has been added in case of leaving the session alone.
 
 ### Version 0.3.0
 - Added support for message encryption over HTTP when using NTLM/Kerberos/CredSSP

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -277,7 +277,7 @@ class Protocol(object):
 
                 raise WinRMError('{0} (extended fault data: {1})'.format(error_message, fault_data))
 
-    def close_shell(self, shell_id, close_session=False):
+    def close_shell(self, shell_id, close_session=True):
         """
         Close the shell
         @param string shell_id: The shell id on the remote machine.

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -277,30 +277,39 @@ class Protocol(object):
 
                 raise WinRMError('{0} (extended fault data: {1})'.format(error_message, fault_data))
 
-    def close_shell(self, shell_id):
+    def close_shell(self, shell_id, close_session=False):
         """
         Close the shell
         @param string shell_id: The shell id on the remote machine.
          See #open_shell
+        @param bool close_session: If we want to close the requests's session.
+         Allows to completely close all TCP connections to the server.
         @returns This should have more error checking but it just returns true
          for now.
         @rtype bool
         """
-        message_id = uuid.uuid4()
-        req = {'env:Envelope': self._get_soap_header(
-            resource_uri='http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd',  # NOQA
-            action='http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete',
-            shell_id=shell_id,
-            message_id=message_id)}
+        try:
+            message_id = uuid.uuid4()
+            req = {'env:Envelope': self._get_soap_header(
+                resource_uri='http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd',  # NOQA
+                action='http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete',
+                shell_id=shell_id,
+                message_id=message_id)}
 
-        # SOAP message requires empty env:Body
-        req['env:Envelope'].setdefault('env:Body', {})
+            # SOAP message requires empty env:Body
+            req['env:Envelope'].setdefault('env:Body', {})
 
-        res = self.send_message(xmltodict.unparse(req))
-        root = ET.fromstring(res)
-        relates_to = next(
-            node for node in root.findall('.//*')
-            if node.tag.endswith('RelatesTo')).text
+            res = self.send_message(xmltodict.unparse(req))
+            root = ET.fromstring(res)
+            relates_to = next(
+                node for node in root.findall('.//*')
+                if node.tag.endswith('RelatesTo')).text
+        finally:
+            # Close the transport if we are done with the shell.
+            # This will ensure no lingering TCP connections are thrown back into a requests' connection pool.
+            if close_session:
+                self.transport.close_session()
+
         # TODO change assert into user-friendly exception
         assert uuid.UUID(relates_to.replace('uuid:', '')) == message_id
 

--- a/winrm/tests/conftest.py
+++ b/winrm/tests/conftest.py
@@ -351,6 +351,9 @@ class TransportStub(object):
         else:
             raise Exception('Message was not expected\n\n%s' % message)
 
+    def close_session(self):
+        pass
+
 
 @fixture(scope='module')
 def protocol_fake(request):

--- a/winrm/tests/test_protocol.py
+++ b/winrm/tests/test_protocol.py
@@ -7,8 +7,7 @@ def test_open_shell_and_close_shell(protocol_fake):
     shell_id = protocol_fake.open_shell()
     assert shell_id == '11111111-1111-1111-1111-111111111113'
 
-    protocol_fake.close_shell(shell_id)
-    assert protocol_fake.transport is None
+    protocol_fake.close_shell(shell_id, close_session=True)
 
 
 def test_run_command_with_arguments_and_cleanup_command(protocol_fake):

--- a/winrm/tests/test_protocol.py
+++ b/winrm/tests/test_protocol.py
@@ -8,6 +8,7 @@ def test_open_shell_and_close_shell(protocol_fake):
     assert shell_id == '11111111-1111-1111-1111-111111111113'
 
     protocol_fake.close_shell(shell_id)
+    assert protocol_fake.transport is None
 
 
 def test_run_command_with_arguments_and_cleanup_command(protocol_fake):

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -261,7 +261,7 @@ class TestTransport(unittest.TestCase):
         t_default.build_session()
         t_default.close_session()
         mock_session.return_value.close.assert_called_once_with()
-        self.assertIsNotNone(t_default.session)
+        self.assertIsNone(t_default.session)
 
     @mock.patch('requests.Session')
     def test_close_session_not_built(self, mock_session):

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -282,6 +282,7 @@ class Transport(object):
         if not self.session:
             return
         self.session.close()
+        self.session = None
 
     def send_message(self, message):
         if not self.session:

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -282,7 +282,6 @@ class Transport(object):
         if not self.session:
             return
         self.session.close()
-        self.session = None
 
     def send_message(self, message):
         if not self.session:

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -278,6 +278,12 @@ class Transport(object):
         self._send_message_request(prepared_request, '')
         self.encryption = Encryption(self.session, self.auth_method)
 
+    def close_session(self):
+        if not self.session:
+            return
+        self.session.close()
+        self.session = None
+
     def send_message(self, message):
         if not self.session:
             self.build_session()


### PR DESCRIPTION
This will allow for completely disconnecting from the server if the shell has closed, closing all TCP connections. The existing behavior should be the same. 

There was some unit tests added to mock requests in PR https://github.com/diyan/pywinrm/pull/131 . If you would like additional unit tests, I can either wait for that PR to be merged or move both code into one to re-use what is there.
