### PR TITLE
Added service to HTTPKerberosAuth

### DIFF
--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -130,7 +130,7 @@ class Transport(object):
             session.auth = HTTPKerberosAuth(mutual_authentication=REQUIRED, delegate=self.kerberos_delegation,
                                             force_preemptive=True, principal=self.username,
                                             hostname_override=self.kerberos_hostname_override,
-                                            sanitize_mutual_error_response=False)
+                                            sanitize_mutual_error_response=False, service=self.service)
         elif self.auth_method in ['certificate','ssl']:
             if self.auth_method == 'ssl' and not self.cert_pem and not self.cert_key_pem:
                 # 'ssl' was overloaded for HTTPS with optional certificate auth,


### PR DESCRIPTION
Added option for service to HTTPKerberosAuth. This is to resolve issues with Ansible and Service Principle Names (SPN). The default service is HTTP but has no option to adjust this value. Ansible passes variables for winrm_service but that doesn't get passed to HTTPKerberosAuth. This change corrects that defect.

[kerberos: the specified credentials were rejected by the server, ssl: 401 Unauthorized. #17758](https://github.com/ansible/ansible/issues/17758)
