### PR TITLE
Emit as detailed error messages as possible when the fault isn't of transport.

### DIFF
--- a/winrm/exceptions.py
+++ b/winrm/exceptions.py
@@ -7,7 +7,26 @@ class WinRMError(Exception):
 
 class WinRMTransportError(Exception):
     """WinRM errors specific to transport-level problems (unexpcted HTTP error codes, etc)"""
-    code = 500
+
+    @property
+    def protocol(self):
+        return self.args[0]
+
+    @property
+    def code(self):
+        return self.args[1]
+
+    @property
+    def message(self):
+        return 'Bad HTTP response returned from server. Code {0}'.format(self.code)
+
+    @property
+    def response_text(self):
+        return self.args[2]
+
+    def __str__(self):
+        return self.message
+
 
 class WinRMOperationTimeoutError(Exception):
     """

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -181,11 +181,5 @@ class Transport(object):
                 response_text = ex.response.content
             else:
                 response_text = ''
-            # Per http://msdn.microsoft.com/en-us/library/cc251676.aspx rule 3,
-            # should handle this 500 error and retry receiving command output.
-            if b'http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive' in message and b'Code="2150858793"' in response_text:
-                raise WinRMOperationTimeoutError()
 
-            error_message = 'Bad HTTP response returned from server. Code {0}'.format(ex.response.status_code)
-
-            raise WinRMTransportError('http', error_message)
+            raise WinRMTransportError('http', ex.response.status_code, response_text)


### PR DESCRIPTION
If it is an application-level fault and the endpoint returns a vaild SOAP envelope, the current implementation throws off the entire message and simply reports it as a transport failure, which is not helpful.

This patch modifies `winrm.protocol.Protocol.send_message` so 

1. it raises WinRMError instead of WinRMTransportError when the fault isn't of transport.
2. the raised exception contains the fault code, subcode and reason text from the payload when applicable.
