### PR TITLE
Added support for specifying proxy dictionary as required by Python requests module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ matrix:
     - { os: osx, osx_image: xcode8.2, language: generic, env: OSX=10.12 PYENV=3.5.4 }
 
 install:
-  # Just for docker build
-  - apt-get update
-  - apt-get install -y build-essentials git readline6-dev zlib1g-dev libbz2-dev libssl-dev libsqlite3-dev libkrb5-dev
   # Always use latest pyenv but keep installed Python versions in cache
   - rm -rf ~/.pyenv
   - git clone https://github.com/yyuu/pyenv.git ~/.pyenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,34 +12,31 @@ matrix:
   include:
     # Python 3.0-3.2 does not support explicit unicode literal, see pep-0414
     # Define 'sudo: false' to run on container-based workers
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=2.6.9 }
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=2.7.13 }
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.3.6 }
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.4.5 }
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.5.2 }
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.6-dev }
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=pypy2-5.6.0 }
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=pypy3.3-5.5-alpha }
+    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=2.7.14 }
+    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.4.7 }
+    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.5.4 }
+    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.6.3 }
+    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=pypy2.7-5.9.0 }
 
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=2.6.9 }
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=2.7.13 }
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.3.6 }
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.4.5 }
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.5.2 }
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.6-dev }
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=pypy2-5.6.0 }
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=pypy3.3-5.5-alpha }
+    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=2.7.14 }
+    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.4.7 }
+    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.5.4 }
+    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.6.3 }
+    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=pypy2.7-5.9.0 }
 
-    - { os: osx, osx_image: xcode6.4, language: generic, env: OSX=10.10 PYENV=2.7.13 }
-    - { os: osx, osx_image: xcode6.4, language: generic, env: OSX=10.10 PYENV=3.5.2 }
+    - { os: osx, osx_image: xcode6.4, language: generic, env: OSX=10.10 PYENV=2.7.14 }
+    - { os: osx, osx_image: xcode6.4, language: generic, env: OSX=10.10 PYENV=3.5.4 }
 
-    - { os: osx, osx_image: xcode7, language: generic, env: OSX=10.11 PYENV=2.7.13 }
-    - { os: osx, osx_image: xcode7, language: generic, env: OSX=10.11 PYENV=3.5.2 }
+    - { os: osx, osx_image: xcode7, language: generic, env: OSX=10.11 PYENV=2.7.14 }
+    - { os: osx, osx_image: xcode7, language: generic, env: OSX=10.11 PYENV=3.5.4 }
 
-    - { os: osx, osx_image: xcode8.2, language: generic, env: OSX=10.12 PYENV=2.7.13 }
-    - { os: osx, osx_image: xcode8.2, language: generic, env: OSX=10.12 PYENV=3.5.2 }
+    - { os: osx, osx_image: xcode8.2, language: generic, env: OSX=10.12 PYENV=2.7.14 }
+    - { os: osx, osx_image: xcode8.2, language: generic, env: OSX=10.12 PYENV=3.5.4 }
 
 install:
+  # Just for docker build
+  - apt-get update
+  - apt-get install -y build-essentials git readline6-dev zlib1g-dev libbz2-dev libssl-dev libsqlite3-dev libkrb5-dev
   # Always use latest pyenv but keep installed Python versions in cache
   - rm -rf ~/.pyenv
   - git clone https://github.com/yyuu/pyenv.git ~/.pyenv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Developing
 - Added support for message encryption over HTTP when using NTLM and CredSSP
 - Added parameter to disable TLSv1.2 when using CredSSP for Server 2008 support
+- Added proxy support (pass proxy dict straight to requests)
 
 ### Version 0.2.2
 - Added support for CredSSP authenication (via requests-credssp)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,15 +6,17 @@ environment:
     WITH_COMPILER: "cmd /E:ON /V:ON /C .\\scripts\\run_with_compiler.cmd"
   matrix:
     # https://www.appveyor.com/docs/installed-software/#python
-    # NOTE Python 2.6 for Windows is no longer supported by the Python core team
+    # NOTE These Python versions are no longer supported by the Python core team on Windows
+    #  * 2.6
+    #  * 3.3
     - PYTHON: Python27
     - PYTHON: Python27-x64
-    - PYTHON: Python33
-    - PYTHON: Python33-x64
     - PYTHON: Python34
     - PYTHON: Python34-x64
     - PYTHON: Python35
     - PYTHON: Python35-x64
+    - PYTHON: Python36
+    - PYTHON: Python36-x64
 init:
   - ps: |
       $ErrorActionPreference = "Stop"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 # this assumes the base requirements have been satisfied via setup.py
-pytest
+pytest<=3.2.5
 pytest-cov
 pytest-pep8
 mock

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -31,7 +31,8 @@ class Protocol(object):
             operation_timeout_sec=DEFAULT_OPERATION_TIMEOUT_SEC,
             kerberos_hostname_override=None,
             message_encryption='auto',
-            credssp_disable_tlsv1_2=False
+            credssp_disable_tlsv1_2=False,
+            proxies=None
         ):
         """
         @param string endpoint: the WinRM webservice endpoint
@@ -50,6 +51,7 @@ class Protocol(object):
         @param int operation_timeout_sec: maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. # NOQA
         @param string kerberos_hostname_override: the hostname to use for the kerberos exchange (defaults to the hostname in the endpoint URL)
         @param bool message_encryption_enabled: Will encrypt the WinRM messages if set to True and the transport auth supports message encryption (Default True).
+        @param dict proxies: A dictionary of proxies to pass onto Python requests (default is to use environment variables)
         """
 
         if operation_timeout_sec >= read_timeout_sec or operation_timeout_sec < 1:
@@ -70,7 +72,8 @@ class Protocol(object):
             kerberos_hostname_override=kerberos_hostname_override,
             auth_method=transport,
             message_encryption=message_encryption,
-            credssp_disable_tlsv1_2=credssp_disable_tlsv1_2
+            credssp_disable_tlsv1_2=credssp_disable_tlsv1_2,
+            proxies=proxies
         )
 
         self.username = username

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -149,6 +149,7 @@ class Transport(object):
 
         session.verify = self.server_cert_validation == 'validate'
 
+        # pragma: no cover
         if self.proxies and type(self.proxies) == dict:
             # Use provided proxies
             session.proxies = self.proxies

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -65,7 +65,8 @@ class Transport(object):
             kerberos_hostname_override=None,
             auth_method='auto',
             message_encryption='auto',
-            credssp_disable_tlsv1_2=False):
+            credssp_disable_tlsv1_2=False,
+            proxies=None):
         self.endpoint = endpoint
         self.username = username
         self.password = password
@@ -80,6 +81,7 @@ class Transport(object):
         self.kerberos_hostname_override = kerberos_hostname_override
         self.message_encryption = message_encryption
         self.credssp_disable_tlsv1_2 = credssp_disable_tlsv1_2
+        self.proxies = {} if proxies is None else proxies
 
         if self.server_cert_validation not in [None, 'validate', 'ignore']:
             raise WinRMError('invalid server_cert_validation mode: %s' % self.server_cert_validation)
@@ -147,12 +149,12 @@ class Transport(object):
 
         session.verify = self.server_cert_validation == 'validate'
 
-        # configure proxies from HTTP/HTTPS_PROXY envvars
+        # configure proxies from HTTP/HTTPS_PROXY envvars and from given proxy values
         session.trust_env = True
-        settings = session.merge_environment_settings(url=self.endpoint, proxies={}, stream=None,
+        settings = session.merge_environment_settings(url=self.endpoint, proxies=self.proxies, stream=None,
                                                       verify=None, cert=None)
 
-        # we're only applying proxies from env, other settings are ignored
+        # Applying proxy settings
         session.proxies = settings['proxies']
 
         encryption_available = False


### PR DESCRIPTION
I've added support for specifying a proxy dictionary so that the Python requests module can accept this. If no proxy dictionary is specified then the fallback is to use the environment which is what PyWinRM currently does. This PR addresses issue #149.