### PR TITLE
Allow internal Certificate Authority

### DIFF
--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -11,11 +11,11 @@ def test_build_session():
                           auth_method='basic',
                           )
     os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
-    session = transport.build_session()
-    assert(session.verify == 'path_to_REQUESTS_CA_CERT')
+    transport.build_session()
+    assert(transport.session.verify == 'path_to_REQUESTS_CA_CERT')
     del os.environ['REQUESTS_CA_BUNDLE']
 
     os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
-    session = transport.build_session()
-    assert(session.verify == 'path_to_CURL_CA_CERT')
+    transport.build_session()
+    assert(transport.session.verify == 'path_to_CURL_CA_CERT')
     del os.environ['CURL_CA_BUNDLE']

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -1,0 +1,21 @@
+# coding=utf-8
+import os
+from winrm.transport import Transport
+
+
+def test_build_session():
+    transport = Transport(endpoint="Endpoint",
+                          server_cert_validation='validate',
+                          username='test',
+                          password='test',
+                          auth_method='basic',
+                          )
+    os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+    session = transport.build_session()
+    assert(session.verify == 'path_to_REQUESTS_CA_CERT')
+    del os.environ['REQUESTS_CA_BUNDLE']
+
+    os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
+    session = transport.build_session()
+    assert(session.verify == 'path_to_CURL_CA_CERT')
+    del os.environ['CURL_CA_BUNDLE']

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -135,8 +135,11 @@ class Transport(object):
         settings = session.merge_environment_settings(url=self.endpoint, proxies={}, stream=None,
                                                       verify=None, cert=None)
 
-        # we're only applying proxies from env, other settings are ignored
+        # we're only applying proxies and/or verify from env, other settings are ignored
         session.proxies = settings['proxies']
+
+        if settings['verify'] is not None or self.ca_trust_path is not None:
+            session.verify = self.ca_trust_path or settings['verify']
 
         if self.auth_method == 'kerberos':
             if not HAVE_KERBEROS:


### PR DESCRIPTION
If ca_trust_path is passed into winrm.Protocol, it is generally ignored. This change uses it as well as the possible request environment variables (REQUESTS_CA_BUNDLE and CURL_CA_BUNDLE) to trust a local CA.