### PR TITLE
Gives pywinrm the http_proxy and https_proxy parameters support

### DIFF
--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -30,6 +30,8 @@ class Protocol(object):
             read_timeout_sec=DEFAULT_READ_TIMEOUT_SEC,
             operation_timeout_sec=DEFAULT_OPERATION_TIMEOUT_SEC,
             kerberos_hostname_override=None,
+            http_proxy=None,
+            https_proxy=None,
         ):
         """
         @param string endpoint: the WinRM webservice endpoint
@@ -47,6 +49,8 @@ class Protocol(object):
         @param int read_timeout_sec: maximum seconds to wait before an HTTP connect/read times out (default 30). This value should be slightly higher than operation_timeout_sec, as the server can block *at least* that long. # NOQA
         @param int operation_timeout_sec: maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. # NOQA
         @param string kerberos_hostname_override: the hostname to use for the kerberos exchange (defaults to the hostname in the endpoint URL)
+        @param string http_proxy: to override the current environment http_proxy var
+        @param string https_proxy: to override the current environment https_proxy var
         """
 
         if operation_timeout_sec >= read_timeout_sec or operation_timeout_sec < 1:
@@ -65,7 +69,8 @@ class Protocol(object):
             server_cert_validation=server_cert_validation,
             kerberos_delegation=kerberos_delegation,
             kerberos_hostname_override=kerberos_hostname_override,
-            auth_method=transport)
+            auth_method=transport,
+            http_proxy=http_proxy, https_proxy=https_proxy)
 
         self.username = username
         self.password = password
@@ -75,6 +80,8 @@ class Protocol(object):
         self.server_cert_validation = server_cert_validation
         self.kerberos_delegation = kerberos_delegation
         self.kerberos_hostname_override = kerberos_hostname_override
+        self.http_proxy = http_proxy
+        self.https_proxy = https_proxy
 
     def open_shell(self, i_stream='stdin', o_stream='stdout stderr',
                    working_directory=None, env_vars=None, noprofile=False,

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -59,7 +59,9 @@ class Transport(object):
             cert_key_pem=None, read_timeout_sec=None, server_cert_validation='validate',
             kerberos_delegation=False,
             kerberos_hostname_override=None,
-            auth_method='auto'):
+            auth_method='auto',
+            http_proxy=None,
+            https_proxy=None):
         self.endpoint = endpoint
         self.username = username
         self.password = password
@@ -72,6 +74,8 @@ class Transport(object):
         self.read_timeout_sec = read_timeout_sec
         self.server_cert_validation = server_cert_validation
         self.kerberos_hostname_override = kerberos_hostname_override
+        self.http_proxy = http_proxy
+        self.https_proxy = https_proxy
 
         if self.server_cert_validation not in [None, 'validate', 'ignore']:
             raise WinRMError('invalid server_cert_validation mode: %s' % self.server_cert_validation)
@@ -138,6 +142,10 @@ class Transport(object):
         # we're only applying proxies from env, other settings are ignored
         session.proxies = settings['proxies']
 
+        # We override the environment with passed values when they're defined
+        if self.http_proxy: session.proxies['http'] = self.http_proxy
+        if self.https_proxy: session.proxies['https'] = self.https_proxy
+        
         if self.auth_method == 'kerberos':
             if not HAVE_KERBEROS:
                 raise WinRMError("requested auth method is kerberos, but requests_kerberos is not installed")


### PR DESCRIPTION
This change allows to use a per host (or in group_vars) https proxy (like https_proxy=socks5://user:pass@socksserver:port) in Ansible since the standard "request" python module can't be "socksified" (using tsocks or socksify binaries).

Just put "ansible_winrm_http_proxy" or "ansible_winrm_https_proxy" in your host inventories and it will be good to go since Ansible pass every var whose name starts with "ansible_winrm_*" to the pywinrm module, removing the "ansible_winrm_" prefix.

This is very important for multi network architectures which relies on both Unix and Windows nodes. The only way to "proxyfy" WinRM https using certificates auth is to either do NAT (which basically is really cumbersome to set-up and maintain, using a per node given nated port) or a "man in the middle" proxy, requiring to duplicate certificates on all the proxies (which is a major security flaw).

Being able to use a simple dante server (socks5) is both flexible and secure. You can even create a local SSH tunnel to your socks if you want to harden your security but since all traffic is already on HTTPS there shouldn't be any need for that.

