### PR TITLE
additional filter to supress urllib3 warnings

### DIFF
--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -105,6 +105,11 @@ class Transport(object):
                 from requests.packages.urllib3.exceptions import InsecureRequestWarning
                 warnings.simplefilter('ignore', category=InsecureRequestWarning)
             except: pass # oh well, we tried...
+            
+            try:
+                from urllib3.exceptions import InsecureRequestWarning
+                warnings.simplefilter('ignore', category=InsecureRequestWarning)
+            except: pass # oh well, we tried...
 
         # validate credential requirements for various auth types
         if self.auth_method != 'kerberos':


### PR DESCRIPTION
I had the problem on a RHEL7 server that the old fix did not work for the insecure request warnings.
The proposed change did the job and warnings were not shown anymore.
It seems that requests.packages.urllib3.exceptions does not equal to urllib3.exceptions when using warnings.simplefilter.