### PR TITLE
Add 'wait' parameter flag when running commands

### DIFF
--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -32,11 +32,11 @@ class Session(object):
         self.protocol = Protocol(self.url,
                                  username=username, password=password, **kwargs)
 
-    def run_cmd(self, command, args=()):
+    def run_cmd(self, command, args=(), wait=True):
         # TODO optimize perf. Do not call open/close shell every time
         shell_id = self.protocol.open_shell()
         command_id = self.protocol.run_command(shell_id, command, args)
-        rs = Response(self.protocol.get_command_output(shell_id, command_id))
+        rs = Response(self.protocol.get_command_output(shell_id, command_id, wait))
         self.protocol.cleanup_command(shell_id, command_id)
         self.protocol.close_shell(shell_id)
         return rs

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -319,7 +319,7 @@ class Protocol(object):
         # TODO change assert into user-friendly exception
         assert uuid.UUID(relates_to.replace('uuid:', '')) == message_id
 
-    def get_command_output(self, shell_id, command_id):
+    def get_command_output(self, shell_id, command_id, wait):
         """
         Get the Output of the given shell and command
         @param string shell_id: The shell id on the remote machine.
@@ -340,6 +340,8 @@ class Protocol(object):
                     self._raw_get_command_output(shell_id, command_id)
                 stdout_buffer.append(stdout)
                 stderr_buffer.append(stderr)
+                if not wait and not command_done:
+                    return 'Did not wait for command to finish','',0
             except WinRMOperationTimeoutError as e:
                 # this is an expected error when waiting for a long-running process, just silently retry
                 pass


### PR DESCRIPTION
Allows the response to be skipped. Useful for starting programs or running commands in the background without waiting for them to return a response. If wait==False and command does not return status on first pass, the response ('Did not wait for command to finish','',0) is returned.