### PR TITLE
pass ca_trust_path to requests module

### DIFF
--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -146,6 +146,8 @@ class Transport(object):
         session = requests.Session()
 
         session.verify = self.server_cert_validation == 'validate'
+        if session.verify and self.ca_trust_path:
+                session.verify = self.ca_trust_path
 
         # configure proxies from HTTP/HTTPS_PROXY envvars
         session.trust_env = True


### PR DESCRIPTION
The python requests module uses .verify i) as boolean or ii) path to a custom CA bundle, see http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
This change makes use of the already present ca_trust_path and passes it properly to the requests library, enabling custom CAs in addition to the built-in mozilla chain.

