### PR TITLE
Int parser for timeout and kerb arg support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,17 @@ matrix:
     # Define 'sudo: false' to run on container-based workers
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=2.6.9 }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=2.7.13 }
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.3.6 }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.4.5 }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.5.2 }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.6-dev }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=pypy2-5.6.0 }
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=pypy3.3-5.5-alpha }
 
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=2.6.9 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=2.7.13 }
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.3.6 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.4.5 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.5.2 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.6-dev }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=pypy2-5.6.0 }
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=pypy3.3-5.5-alpha }
 
     - { os: osx, osx_image: xcode6.4, language: generic, env: OSX=10.10 PYENV=2.7.13 }
     - { os: osx, osx_image: xcode6.4, language: generic, env: OSX=10.10 PYENV=3.5.2 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ environment:
     # NOTE Python 2.6 for Windows is no longer supported by the Python core team
     - PYTHON: Python27
     - PYTHON: Python27-x64
-    - PYTHON: Python33
-    - PYTHON: Python33-x64
     - PYTHON: Python34
     - PYTHON: Python34-x64
     - PYTHON: Python35

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 # this assumes the base requirements have been satisfied via setup.py
-pytest
+# pytest>=3.3.0 dropped support for Python 2.6 and 3.3
+pytest<=3.2.5
 pytest-cov
 pytest-pep8
 mock

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -58,6 +58,16 @@ class Protocol(object):
         @param bool message_encryption_enabled: Will encrypt the WinRM messages if set to True and the transport auth supports message encryption (Default True).
         """
 
+        try:
+            read_timeout_sec = int(read_timeout_sec)
+        except ValueError as ve:
+            raise ValueError("failed to parse read_timeout_sec as int: %s" % str(ve))
+
+        try:
+            operation_timeout_sec = int(operation_timeout_sec)
+        except ValueError as ve:
+            raise ValueError("failed to parse operation_timeout_sec as int: %s" % str(ve))
+
         if operation_timeout_sec >= read_timeout_sec or operation_timeout_sec < 1:
             raise WinRMError("read_timeout_sec must exceed operation_timeout_sec, and both must be non-zero")
 

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -29,7 +29,7 @@ class Protocol(object):
 
     def __init__(
             self, endpoint, transport='plaintext', username=None,
-            password=None, realm=None, service=None, keytab=None,
+            password=None, realm=None, service="HTTP", keytab=None,
             ca_trust_path=None, cert_pem=None, cert_key_pem=None,
             server_cert_validation='validate',
             kerberos_delegation=False,
@@ -37,7 +37,8 @@ class Protocol(object):
             operation_timeout_sec=DEFAULT_OPERATION_TIMEOUT_SEC,
             kerberos_hostname_override=None,
             message_encryption='auto',
-            credssp_disable_tlsv1_2=False
+            credssp_disable_tlsv1_2=False,
+            send_cbt=True,
         ):
         """
         @param string endpoint: the WinRM webservice endpoint
@@ -86,7 +87,8 @@ class Protocol(object):
             kerberos_hostname_override=kerberos_hostname_override,
             auth_method=transport,
             message_encryption=message_encryption,
-            credssp_disable_tlsv1_2=credssp_disable_tlsv1_2
+            credssp_disable_tlsv1_2=credssp_disable_tlsv1_2,
+            send_cbt=send_cbt
         )
 
         self.username = username

--- a/winrm/tests/test_protocol.py
+++ b/winrm/tests/test_protocol.py
@@ -1,3 +1,8 @@
+import pytest
+
+from winrm.protocol import Protocol
+
+
 def test_open_shell_and_close_shell(protocol_fake):
     shell_id = protocol_fake.open_shell()
     assert shell_id == '11111111-1111-1111-1111-111111111113'
@@ -34,3 +39,35 @@ def test_get_command_output(protocol_fake):
 
     protocol_fake.cleanup_command(shell_id, command_id)
     protocol_fake.close_shell(shell_id)
+
+
+def test_set_timeout_as_sec():
+    protocol = Protocol('endpoint',
+                        username='username',
+                        password='password',
+                        read_timeout_sec='30',
+                        operation_timeout_sec='29')
+    assert protocol.read_timeout_sec == 30
+    assert protocol.operation_timeout_sec == 29
+
+
+def test_fail_set_read_timeout_as_sec():
+    with pytest.raises(ValueError) as exc:
+        protocol = Protocol('endpoint',
+                            username='username',
+                            password='password',
+                            read_timeout_sec='30a',
+                            operation_timeout_sec='29')
+    assert str(exc.value) == "failed to parse read_timeout_sec as int: " \
+        "invalid literal for int() with base 10: '30a'"
+
+
+def test_fail_set_operation_timeout_as_sec():
+    with pytest.raises(ValueError) as exc:
+        protocol = Protocol('endpoint',
+                            username='username',
+                            password='password',
+                            read_timeout_sec=30,
+                            operation_timeout_sec='29a')
+    assert str(exc.value) == "failed to parse operation_timeout_sec as int: " \
+        "invalid literal for int() with base 10: '29a'"


### PR DESCRIPTION
Attempt to parse the *_timeout_sec variables and fail with a better error message

Will fix the following issues in Ansible without us manually handling it there.
https://github.com/ansible/ansible/issues/33339
https://github.com/ansible/ansible/issues/25539

Also set's a limit on the pytest version to `3.2.5` as `3.3.0` drops support for Python 2.6 and 3.3.