### PR TITLE
Make sure that res.std_out and res.std_err are str

### DIFF
--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -39,6 +39,10 @@ class Session(object):
         rs = Response(self.protocol.get_command_output(shell_id, command_id))
         self.protocol.cleanup_command(shell_id, command_id)
         self.protocol.close_shell(shell_id)
+        if not isinstance(rs.std_err, str):
+            rs.std_err = rs.std_err.decode()
+        if not isinstance(rs.std_out, str):
+            rs.std_out = rs.std_out.decode()
         return rs
 
     def run_ps(self, script):


### PR DESCRIPTION
This should fix the issue #111 since the standard output and error output are sometimes instances of bytes instead of str