### PR TITLE
Support setting a proxy and ignoring proxies from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Version 0.3.1
+- Ensure server_cert_validation=ignore supersedes ca_trust_path/env overrides
+
 ### Version 0.3.0
 - Added support for message encryption over HTTP when using NTLM/Kerberos/CredSSP
 - Added parameter to disable TLSv1.2 when using CredSSP for Server 2008 support

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -39,6 +39,8 @@ class Protocol(object):
             message_encryption='auto',
             credssp_disable_tlsv1_2=False,
             send_cbt=True,
+            proxy=None,
+            proxy_ignore_env=False,
         ):
         """
         @param string endpoint: the WinRM webservice endpoint
@@ -57,6 +59,8 @@ class Protocol(object):
         @param int operation_timeout_sec: maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. # NOQA
         @param string kerberos_hostname_override: the hostname to use for the kerberos exchange (defaults to the hostname in the endpoint URL)
         @param bool message_encryption_enabled: Will encrypt the WinRM messages if set to True and the transport auth supports message encryption (Default True).
+        @param string proxy: Specify a proxy for the WinRM connection to use. The proxy specified here takes precedence over environment varaiables.
+        @param bool proxy_ignore_env: Ignore environment variables when determining if the WinRM connection should use a proxy (default False)
         """
 
         try:
@@ -88,7 +92,9 @@ class Protocol(object):
             auth_method=transport,
             message_encryption=message_encryption,
             credssp_disable_tlsv1_2=credssp_disable_tlsv1_2,
-            send_cbt=send_cbt
+            send_cbt=send_cbt,
+            proxy=proxy,
+            proxy_ignore_env=proxy_ignore_env
         )
 
         self.username = username

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -1,21 +1,63 @@
 # coding=utf-8
 import os
+import tempfile
 from winrm.transport import Transport
 
 
-def test_build_session():
-    transport = Transport(endpoint="Endpoint",
+def test_build_session_cert_validate():
+    t_default = Transport(endpoint="Endpoint",
                           server_cert_validation='validate',
                           username='test',
                           password='test',
                           auth_method='basic',
                           )
-    os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
-    transport.build_session()
-    assert(transport.session.verify == 'path_to_REQUESTS_CA_CERT')
-    del os.environ['REQUESTS_CA_BUNDLE']
+    t_ca_override = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              ca_trust_path='overridepath',
+                              )
+    try:
+        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+        t_default.build_session()
+        t_ca_override.build_session()
+        assert(t_default.session.verify == 'path_to_REQUESTS_CA_CERT')
+        assert(t_ca_override.session.verify == 'overridepath')
+    finally:
+        del os.environ['REQUESTS_CA_BUNDLE']
 
-    os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
-    transport.build_session()
-    assert(transport.session.verify == 'path_to_CURL_CA_CERT')
-    del os.environ['CURL_CA_BUNDLE']
+    try:
+        os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
+        t_default.build_session()
+        t_ca_override.build_session()
+        assert(t_default.session.verify == 'path_to_CURL_CA_CERT')
+        assert (t_ca_override.session.verify == 'overridepath')
+    finally:
+        del os.environ['CURL_CA_BUNDLE']
+
+
+def test_build_session_cert_ignore():
+    t_default = Transport(endpoint="Endpoint",
+                          server_cert_validation='ignore',
+                          username='test',
+                          password='test',
+                          auth_method='basic',
+                          )
+    t_ca_override = Transport(endpoint="Endpoint",
+                              server_cert_validation='ignore',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              ca_trust_path='boguspath'
+                              )
+    try:
+        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+        os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
+        t_default.build_session()
+        t_ca_override.build_session()
+        assert(isinstance(t_default.session.verify, bool) and not t_default.session.verify)
+        assert (isinstance(t_ca_override.session.verify, bool) and not t_ca_override.session.verify)
+    finally:
+        del os.environ['REQUESTS_CA_BUNDLE']
+        del os.environ['CURL_CA_BUNDLE']

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -62,7 +62,9 @@ class Transport(object):
             auth_method='auto',
             message_encryption='auto',
             credssp_disable_tlsv1_2=False,
-            send_cbt=True):
+            send_cbt=True,
+            proxy=None,
+            proxy_ignore_env=False):
         self.endpoint = endpoint
         self.username = username
         self.password = password
@@ -78,6 +80,8 @@ class Transport(object):
         self.message_encryption = message_encryption
         self.credssp_disable_tlsv1_2 = credssp_disable_tlsv1_2
         self.send_cbt = send_cbt
+        self.proxy = proxy
+        self.proxy_use_env = not proxy_ignore_env
 
         if self.server_cert_validation not in [None, 'validate', 'ignore']:
             raise WinRMError('invalid server_cert_validation mode: %s' % self.server_cert_validation)
@@ -113,7 +117,7 @@ class Transport(object):
                 from requests.packages.urllib3.exceptions import InsecureRequestWarning
                 warnings.simplefilter('ignore', category=InsecureRequestWarning)
             except: pass # oh well, we tried...
-            
+
             try:
                 from urllib3.exceptions import InsecureRequestWarning
                 warnings.simplefilter('ignore', category=InsecureRequestWarning)
@@ -147,13 +151,19 @@ class Transport(object):
     def build_session(self):
         session = requests.Session()
 
-        # allow some settings to be merged from env
-        session.trust_env = True
-        settings = session.merge_environment_settings(url=self.endpoint, proxies={}, stream=None,
-                                                      verify=None, cert=None)
+        proxies = dict()
+        if self.proxy is not None:      # pragma: no cover
+            # If there was a proxy specified then use it
+            proxies = {
+                'http': self.proxy,
+                'https': self.proxy
+            }
 
-        # get proxy settings from env
-        # FUTURE: allow proxy to be passed in directly to supersede this value
+        # Merge proxy environment variables
+        session.trust_env = self.proxy_use_env
+        settings = session.merge_environment_settings(url=self.endpoint,
+                      proxies=proxies, stream=None, verify=None, cert=None)
+
         session.proxies = settings['proxies']
 
         # specified validation mode takes precedence


### PR DESCRIPTION
This patch adds support for setting the proxy via a string. It also adds support for ignoring any environment variables that may set proxies.

This patch supersedes PR #165 and PR #151, but should implement what was requested in PR #165.

Example HTTP proxy strings are http://_server_:_port_ and http://_user_:_pass_@_server_:_port_. An example SOCKS5 proxy string is socks5://_user_:_pass_@_server_:_port_.