### PR TITLE
Added several tests based off missing code coverage

### DIFF
--- a/winrm/tests/conftest.py
+++ b/winrm/tests/conftest.py
@@ -153,7 +153,7 @@ run_cmd_wo_args_request = """\
   </env:Body>
 </env:Envelope>"""
 
-run_cmd_response = """\
+run_cmd_ps_response = """\
 <?xml version="1.0" ?>
 <s:Envelope xml:lang="en-US" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer">
     <s:Header>
@@ -164,10 +164,41 @@ run_cmd_response = """\
     </s:Header>
     <s:Body>
         <rsp:CommandResponse>
-            <rsp:CommandId>11111111-1111-1111-1111-111111111114</rsp:CommandId>
+            <rsp:CommandId>11111111-1111-1111-1111-1111111111%s4</rsp:CommandId>
         </rsp:CommandResponse>
     </s:Body>
 </s:Envelope>"""
+
+# PS request is Write-Error "Error"
+run_ps_request = """\
+<?xml version="1.0" encoding="utf-8"?>
+<env:Envelope xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:cfg="http://schemas.microsoft.com/wbem/wsman/1/config" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+  <env:Header>
+    <a:To>http://windows-host:5985/wsman</a:To>
+    <a:ReplyTo>
+      <a:Address mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+    </a:ReplyTo>
+    <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+    <a:MessageID>uuid:11111111-1111-1111-1111-111111111111</a:MessageID>
+    <w:Locale mustUnderstand="false" xml:lang="en-US" />
+    <p:DataLocale mustUnderstand="false" xml:lang="en-US" />
+    <w:OperationTimeout>PT20S</w:OperationTimeout>
+    <w:ResourceURI mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+    <a:Action mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command</a:Action>
+    <w:SelectorSet>
+      <w:Selector Name="ShellId">11111111-1111-1111-1111-111111111113</w:Selector>
+    </w:SelectorSet>
+    <w:OptionSet>
+      <w:Option Name="WINRS_CONSOLEMODE_STDIN">TRUE</w:Option>
+      <w:Option Name="WINRS_SKIP_CMD_SHELL">FALSE</w:Option>
+    </w:OptionSet>
+  </env:Header>
+  <env:Body>
+    <rsp:CommandLine>
+      <rsp:Command>powershell -encodedcommand VwByAGkAdABlAC0ARQByAHIAbwByACAAIgBFAHIAcgBvAHIAIgA=</rsp:Command>
+    </rsp:CommandLine>
+  </env:Body>
+</env:Envelope>"""
 
 cleanup_cmd_request = """\
 <?xml version="1.0" encoding="utf-8"?>
@@ -189,7 +220,7 @@ cleanup_cmd_request = """\
     </w:SelectorSet>
   </env:Header>
   <env:Body>
-    <rsp:Signal CommandId="11111111-1111-1111-1111-111111111114">
+    <rsp:Signal CommandId="11111111-1111-1111-1111-1111111111%s4">
       <rsp:Code>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate</rsp:Code>
     </rsp:Signal>
   </env:Body>
@@ -209,7 +240,7 @@ cleanup_cmd_response = """\
     </s:Body>
 </s:Envelope>"""
 
-get_cmd_output_request = """\
+get_cmd_ps_output_request = """\
 <?xml version="1.0" encoding="utf-8"?>
 <env:Envelope xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:cfg="http://schemas.microsoft.com/wbem/wsman/1/config" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing">
   <env:Header>
@@ -230,7 +261,7 @@ get_cmd_output_request = """\
   </env:Header>
   <env:Body>
     <rsp:Receive>
-      <rsp:DesiredStream CommandId="11111111-1111-1111-1111-111111111114">stdout stderr</rsp:DesiredStream>
+      <rsp:DesiredStream CommandId="11111111-1111-1111-1111-1111111111%s4">stdout stderr</rsp:DesiredStream>
     </rsp:Receive>
   </env:Body>
 </env:Envelope>"""
@@ -252,6 +283,28 @@ get_cmd_output_response = """\
             <rsp:Stream CommandId="11111111-1111-1111-1111-111111111114" End="true" Name="stderr"/>
             <rsp:CommandState CommandId="11111111-1111-1111-1111-111111111114" State="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandState/Done">
                 <rsp:ExitCode>0</rsp:ExitCode>
+            </rsp:CommandState>
+        </rsp:ReceiveResponse>
+    </s:Body>
+</s:Envelope>"""
+
+get_ps_output_response = """\
+<?xml version="1.0" ?>
+<s:Envelope xml:lang="en-US" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
+    <s:Header>
+        <a:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/ReceiveResponse</a:Action>
+        <a:MessageID>uuid:11111111-1111-1111-1111-111111111112</a:MessageID>
+        <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+        <a:RelatesTo>uuid:11111111-1111-1111-1111-111111111111</a:RelatesTo>
+    </s:Header>
+    <s:Body>
+        <rsp:ReceiveResponse>
+            <rsp:Stream CommandId="11111111-1111-1111-1111-111111111124" Name="stderr">IzwgQ0xJWE1MDQo=</rsp:Stream>
+            <rsp:Stream Name="stderr" CommandId="11111111-1111-1111-1111-111111111124">PE9ianMgVmVyc2lvbj0iMS4xLjAuMSIgeG1sbnM9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vcG93ZXJzaGVsbC8yMDA0LzA0Ij48UyBTPSJFcnJvciI+V3JpdGUtRXJyb3IgIkVycm9yIiA6IEVycm9yX3gwMDBEX194MDAwQV88L1M+PFMgUz0iRXJyb3IiPiAgICArIENhdGVnb3J5SW5mbyAgICAgICAgICA6IE5vdFNwZWNpZmllZDogKDopIFtXcml0ZS1FcnJvcl0sIFdyaXRlRXJyb3JFeGNlcCBfeDAwMERfX3gwMDBBXzwvUz48UyBTPSJFcnJvciI+ICAgdGlvbl94MDAwRF9feDAwMEFfPC9TPjxTIFM9IkVycm9yIj4gICAgKyBGdWxseVF1YWxpZmllZEVycm9ySWQgOiBNaWNyb3NvZnQuUG93ZXJTaGVsbC5Db21tYW5kcy5Xcml0ZUVycm9yRXhjZXB0aW8gX3gwMDBEX194MDAwQV88L1M+PFMgUz0iRXJyb3IiPiAgIG5feDAwMERfX3gwMDBBXzwvUz48UyBTPSJFcnJvciI+IF94MDAwRF9feDAwMEFfPC9TPjwvT2Jqcz4=</rsp:Stream>
+            <rsp:Stream CommandId="11111111-1111-1111-1111-111111111124" End="true" Name="stdout"/>
+            <rsp:Stream CommandId="11111111-1111-1111-1111-111111111124" End="true" Name="stderr"/>
+            <rsp:CommandState CommandId="11111111-1111-1111-1111-111111111124" State="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandState/Done">
+                <rsp:ExitCode>1</rsp:ExitCode>
             </rsp:CommandState>
         </rsp:ReceiveResponse>
     </s:Body>
@@ -284,13 +337,19 @@ class TransportStub(object):
         elif xml_str_compare(
                 message, run_cmd_with_args_request) or xml_str_compare(
                 message, run_cmd_wo_args_request):
-            return run_cmd_response
-        elif xml_str_compare(message, cleanup_cmd_request):
+            return run_cmd_ps_response % '1'
+        elif xml_str_compare(message, run_ps_request):
+            return run_cmd_ps_response % '2'
+        elif xml_str_compare(
+                message, cleanup_cmd_request % '1') or xml_str_compare(
+                message, cleanup_cmd_request % '2'):
             return cleanup_cmd_response
-        elif xml_str_compare(message, get_cmd_output_request):
+        elif xml_str_compare(message, get_cmd_ps_output_request % '1'):
             return get_cmd_output_response
+        elif xml_str_compare(message, get_cmd_ps_output_request % '2'):
+            return get_ps_output_response
         else:
-            raise Exception('Message was not expected')
+            raise Exception('Message was not expected\n\n%s' % message)
 
 
 @fixture(scope='module')

--- a/winrm/tests/test_session.py
+++ b/winrm/tests/test_session.py
@@ -13,6 +13,18 @@ def test_run_cmd(protocol_fake):
     assert len(r.std_err) == 0
 
 
+def test_run_ps_with_error(protocol_fake):
+    # TODO this test should cover __init__ method
+    s = Session('windows-host', auth=('john.smith', 'secret'))
+    s.protocol = protocol_fake
+
+    r = s.run_ps('Write-Error "Error"')
+
+    assert r.status_code == 1
+    assert b'Write-Error "Error"' in r.std_err
+    assert len(r.std_out) == 0
+
+
 def test_target_as_hostname():
     s = Session('windows-host', auth=('john.smith', 'secret'))
     assert s.url == 'http://windows-host:5985/wsman'

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 import os
+import pytest
 from winrm.transport import Transport
+from winrm.exceptions import WinRMError, InvalidCredentialsError
 
 
 def test_build_session_cert_validate():
@@ -60,3 +62,88 @@ def test_build_session_cert_ignore():
     finally:
         del os.environ['REQUESTS_CA_BUNDLE']
         del os.environ['CURL_CA_BUNDLE']
+
+
+def test_build_session_server_cert_validation_invalid():
+    with pytest.raises(WinRMError) as exc:
+        transport = Transport(endpoint="Endpoint",
+                              server_cert_validation='invalid_value',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              )
+    assert str(exc.value) == 'invalid server_cert_validation mode: invalid_value'
+
+
+def test_build_session_krb_delegation_as_str():
+    transport = Transport(endpoint="Endpoint",
+                          server_cert_validation='validate',
+                          username='test',
+                          password='test',
+                          auth_method='kerberos',
+                          kerberos_delegation='True'
+                          )
+    assert(transport.kerberos_delegation is True)
+
+
+def test_build_session_krb_delegation_as_invalid_str():
+    with pytest.raises(ValueError) as exc:
+        transport = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='kerberos',
+                              kerberos_delegation='invalid_value'
+                              )
+    assert str(exc.value) == "invalid truth value 'invalid_value'"
+
+
+def test_build_session_no_username():
+    with pytest.raises(InvalidCredentialsError) as exc:
+        transport = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              password='test',
+                              auth_method='basic',
+                              )
+        transport.build_session()
+
+    assert str(exc.value) == "auth method basic requires a username"
+
+
+def test_build_session_no_password():
+    with pytest.raises(InvalidCredentialsError) as exc:
+        transport = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              auth_method='basic',
+                              )
+        transport.build_session()
+
+    assert str(exc.value) == "auth method basic requires a password"
+
+
+def test_build_session_invalid_auth():
+    with pytest.raises(WinRMError) as exc:
+        transport = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='invalid_value',
+                              )
+        transport.build_session()
+
+    assert str(exc.value) == "unsupported auth method: invalid_value"
+
+
+def test_build_session_invalid_encryption():
+    with pytest.raises(WinRMError) as exc:
+        transport = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              message_encryption='invalid_value'
+                              )
+        transport.build_session()
+
+    assert str(exc.value) == "invalid message_encryption arg: invalid_value. Should be 'auto', 'always', or 'never'"


### PR DESCRIPTION
This PR relates to #197.

I've added the following tests for Transport.build_session:
- Testing that a trusted CA path sets session.verify regardless of server_cert_validation
- Tested server_cert_validation=ignore code path
- Tested invalid server_cert_validation value
- Tested Kerberos delegation value as both valid and invalid string
- Tested not providing a username or password when they should be required
- Tested setting an invalid authentication mechanism
- Tested setting an invalid encryption setting

I've also added a Session.run_ps test which should test various code paths. The test returns an error, so the std_err and return code are also tested.