### PR TITLE
Fix py26 fault sniff

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = '0.3.0'
+__version__ = '0.3.1.dev0'
 project_name = 'pywinrm'
 
 # PyPi supports only reStructuredText, so pandoc should be installed

--- a/winrm/tests/test_integration_protocol.py
+++ b/winrm/tests/test_integration_protocol.py
@@ -1,6 +1,8 @@
 # coding=utf-8
-import re
 import pytest
+import re
+import sys
+from winrm.exceptions import WinRMError
 xfail = pytest.mark.xfail
 
 
@@ -77,6 +79,15 @@ def test_run_command_taking_more_than_operation_timeout_sec(protocol_real):
     protocol_real.close_shell(shell_id)
 
 
+def test_fault(protocol_real):
+    with pytest.raises(WinRMError) as e:
+        # ask for a bogus shell/command ID to trigger a fault
+        protocol_real.get_command_output(0, 0)
+
+    assert(e.value.code == 500)
+    assert('did not contain all required selectors' in str(e.value))
+
+
 @xfail()
 def test_set_timeout(protocol_real):
     raise NotImplementedError()
@@ -90,3 +101,4 @@ def test_set_max_env_size(protocol_real):
 @xfail()
 def test_set_locale(protocol_real):
     raise NotImplementedError()
+

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import os
-import tempfile
 import pytest
 from winrm.transport import Transport
 from winrm.exceptions import WinRMError, InvalidCredentialsError
@@ -63,41 +62,6 @@ def test_build_session_cert_ignore():
     finally:
         del os.environ['REQUESTS_CA_BUNDLE']
         del os.environ['CURL_CA_BUNDLE']
-
-
-def test_build_session_ca_trust_path():
-    transport = Transport(endpoint="Endpoint",
-                          server_cert_validation='validate',
-                          username='test',
-                          password='test',
-                          auth_method='basic',
-                          ca_trust_path=True
-                          )
-    transport.build_session()
-    assert(transport.ca_trust_path is True)
-    assert(transport.session.verify is True)
-
-    transport = Transport(endpoint="Endpoint",
-                          server_cert_validation='ignore',
-                          username='test',
-                          password='test',
-                          auth_method='basic',
-                          ca_trust_path=True
-                          )
-    transport.build_session()
-    assert(transport.ca_trust_path is True)
-    assert(transport.session.verify is True)
-
-
-def test_build_session_server_cert_validation_ignore():
-    transport = Transport(endpoint="Endpoint",
-                          server_cert_validation='ignore',
-                          username='test',
-                          password='test',
-                          auth_method='basic',
-                          )
-    transport.build_session()
-    assert(transport.session.verify is False)
 
 
 def test_build_session_server_cert_validation_invalid():


### PR DESCRIPTION
Might want to revisit namespace expansion or just don't try to inspect fault data on Py2.6 instead- lxml is a heavyweight requirement...

@mcassaniti This includes most changes from #198 (originally started as trying to fix the merge conflict)- collapsed/removed a couple tests that were already implemented by something else.