### PR TITLE
Added CredSSP changes to support kerb auth and newer protocol changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.6-dev }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=pypy2-5.6.0 }
 
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=2.6.9 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=2.7.13 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.4.5 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.5.2 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 0.3.1
 - Ensure server_cert_validation=ignore supersedes ca_trust_path/env overrides
+- Set minimum version of requests-credssp to support Kerberos auth over CredSSP and other changes
 
 ### Version 0.3.0
 - Added support for message encryption over HTTP when using NTLM/Kerberos/CredSSP

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,9 @@ init:
 
 install:
   - ps: |
+      Enable-WSManCredSSP -Role Server -Force
       Set-Item WSMan:\localhost\Service\Auth\Basic $true
+      Set-Item WSMan:\localhost\Service\Auth\CredSSP $true
       Set-Item WSMan:\localhost\Service\AllowUnencrypted $true
       Invoke-Expression $($env:WITH_COMPILER + " pip install cffi coveralls")
       pip install .
@@ -50,6 +52,10 @@ test_script:
       # Run integration tests with NTLM to check message encryption
       $env:WINRM_TRANSPORT="ntlm"
       Set-Item WSMan:\localhost\Service\AllowUnencrypted $false
+      py.test -v winrm/tests/test_integration_protocol.py winrm/tests/test_integration_session.py
+
+      # Run integration tests with CredSSP to check message encryption
+      $env:WINRM_TRANSPORT="credssp"
       py.test -v winrm/tests/test_integration_protocol.py winrm/tests/test_integration_session.py
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ install:
       Invoke-Expression $($env:WITH_COMPILER + " pip install cffi coveralls")
       pip install .
       pip install -r requirements-test.txt
+      pip install .[credssp]
 
 build: off  # Do not run MSBuild, build stuff at install step
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=('winrm', 'winrm.tests'),
     package_data={'winrm.tests': ['*.ps1']},
     install_requires=['xmltodict', 'requests>=2.9.1', 'requests_ntlm>=0.3.0', 'six'],
-    extras_require = dict(kerberos=['requests-kerberos>=0.10.0'], credssp=['requests-credssp>=0.0.1']),
+    extras_require = dict(kerberos=['requests-kerberos>=0.10.0'], credssp=['requests-credssp>=1.0.0']),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
Set the minimum version of the requests-credssp client to 1.0.0 due to recent changes in that library. Due to a bug where each session was created per session instead of per host I've had to deprecate the old interface and create a new one that is similar to the requests-kerberos interface. This PR also brings in some more configuration options around CredSSP auth that were introduced by Microsoft in a recent security patch.

These changes are reliant on https://github.com/jborean93/requests-credssp/pull/7 being merged and released to Pypi.