### PR TITLE
Fix for session clixml encoding on Python 3

### DIFF
--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -85,10 +85,11 @@ class Session(object):
                 # otherwise the original error message will be used
                 if len(new_msg):
                     # remove leading and trailing whitespace while we are here
-                    msg = new_msg.strip()
-                return msg.encode('utf-8')
-        else:
-            return msg
+                    return new_msg.strip().encode('utf-8')
+
+        # either failed to decode CLIXML or there was nothing to decode
+        # just return the original message
+        return msg
 
     def _strip_namespace(self, xml):
         """strips any namespaces from an xml string"""

--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -86,7 +86,9 @@ class Session(object):
                 if len(new_msg):
                     # remove leading and trailing whitespace while we are here
                     msg = new_msg.strip()
-        return msg.encode('utf-8')
+                return msg.encode('utf-8')
+        else:
+            return msg
 
     def _strip_namespace(self, xml):
         """strips any namespaces from an xml string"""

--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -59,7 +59,7 @@ class Session(object):
         """
         # TODO prepare unit test, beautify code
         # if the msg does not start with this, return it as is
-        if msg.startswith("#< CLIXML\r\n"):
+        if msg.startswith(b"#< CLIXML\r\n"):
             # for proper xml, we need to remove the CLIXML part
             # (the first line)
             msg_xml = msg[11:]
@@ -86,18 +86,15 @@ class Session(object):
                 if len(new_msg):
                     # remove leading and trailing whitespace while we are here
                     msg = new_msg.strip()
-        return msg
+        return msg.encode('utf-8')
 
     def _strip_namespace(self, xml):
         """strips any namespaces from an xml string"""
-        try:
-            p = re.compile("xmlns=*[\"\"][^\"\"]*[\"\"]")
-            allmatches = p.finditer(xml)
-            for match in allmatches:
-                xml = xml.replace(match.group(), "")
-            return xml
-        except Exception as e:
-            raise Exception(e)
+        p = re.compile(b"xmlns=*[\"\"][^\"\"]*[\"\"]")
+        allmatches = p.finditer(xml)
+        for match in allmatches:
+            xml = xml.replace(match.group(), b"")
+        return xml
 
     @staticmethod
     def _build_url(target, transport):

--- a/winrm/tests/test_session.py
+++ b/winrm/tests/test_session.py
@@ -50,3 +50,11 @@ def test_decode_clixml_error():
     expected = b"fake : The term 'fake' is not recognized as the name of a cmdlet, function, script file, or operable program. Check \nthe spelling of the name, or if a path was included, verify that the path is correct and try again.\nAt line:1 char:1\n+ fake cmdlet\n+ ~~~~\n    + CategoryInfo          : ObjectNotFound: (fake:String) [], CommandNotFoundException\n    + FullyQualifiedErrorId : CommandNotFoundException"
     actual = s._clean_error_msg(msg)
     assert actual == expected
+
+
+def test_decode_clixml_no_clixml():
+    s = Session('windows-host.example.com', auth=('john.smith', 'secret'))
+    msg = b"stderr line"
+    expected = b"stderr line"
+    actual = s._clean_error_msg(msg)
+    assert actual == expected

--- a/winrm/tests/test_session.py
+++ b/winrm/tests/test_session.py
@@ -58,3 +58,11 @@ def test_decode_clixml_no_clixml():
     expected = b"stderr line"
     actual = s._clean_error_msg(msg)
     assert actual == expected
+
+
+def test_decode_clixml_no_errors():
+    s = Session('windows-host.example.com', auth=('john.smith', 'secret'))
+    msg = b'#< CLIXML\r\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S="progress" RefId="1"><TNRef RefId="0" /><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>'
+    expected = msg
+    actual = s._clean_error_msg(msg)
+    assert actual == expected

--- a/winrm/tests/test_session.py
+++ b/winrm/tests/test_session.py
@@ -42,3 +42,10 @@ def test_target_as_full_url():
 def test_target_with_dots():
     s = Session('windows-host.example.com', auth=('john.smith', 'secret'))
     assert s.url == 'http://windows-host.example.com:5985/wsman'
+
+def test_decode_clixml_error():
+    s = Session('windows-host.example.com', auth=('john.smith', 'secret'))
+    msg = b'#< CLIXML\r\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S="progress" RefId="1"><TNRef RefId="0" /><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><S S="Error">fake : The term \'fake\' is not recognized as the name of a cmdlet, function, script file, or operable program. Check _x000D__x000A_</S><S S="Error">the spelling of the name, or if a path was included, verify that the path is correct and try again._x000D__x000A_</S><S S="Error">At line:1 char:1_x000D__x000A_</S><S S="Error">+ fake cmdlet_x000D__x000A_</S><S S="Error">+ ~~~~_x000D__x000A_</S><S S="Error">    + CategoryInfo          : ObjectNotFound: (fake:String) [], CommandNotFoundException_x000D__x000A_</S><S S="Error">    + FullyQualifiedErrorId : CommandNotFoundException_x000D__x000A_</S><S S="Error"> _x000D__x000A_</S></Objs>'
+    expected = b"fake : The term 'fake' is not recognized as the name of a cmdlet, function, script file, or operable program. Check \nthe spelling of the name, or if a path was included, verify that the path is correct and try again.\nAt line:1 char:1\n+ fake cmdlet\n+ ~~~~\n    + CategoryInfo          : ObjectNotFound: (fake:String) [], CommandNotFoundException\n    + FullyQualifiedErrorId : CommandNotFoundException"
+    actual = s._clean_error_msg(msg)
+    assert actual == expected

--- a/winrm/tests/test_session.py
+++ b/winrm/tests/test_session.py
@@ -43,6 +43,7 @@ def test_target_with_dots():
     s = Session('windows-host.example.com', auth=('john.smith', 'secret'))
     assert s.url == 'http://windows-host.example.com:5985/wsman'
 
+
 def test_decode_clixml_error():
     s = Session('windows-host.example.com', auth=('john.smith', 'secret'))
     msg = b'#< CLIXML\r\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S="progress" RefId="1"><TNRef RefId="0" /><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><S S="Error">fake : The term \'fake\' is not recognized as the name of a cmdlet, function, script file, or operable program. Check _x000D__x000A_</S><S S="Error">the spelling of the name, or if a path was included, verify that the path is correct and try again._x000D__x000A_</S><S S="Error">At line:1 char:1_x000D__x000A_</S><S S="Error">+ fake cmdlet_x000D__x000A_</S><S S="Error">+ ~~~~_x000D__x000A_</S><S S="Error">    + CategoryInfo          : ObjectNotFound: (fake:String) [], CommandNotFoundException_x000D__x000A_</S><S S="Error">    + FullyQualifiedErrorId : CommandNotFoundException_x000D__x000A_</S><S S="Error"> _x000D__x000A_</S></Objs>'


### PR DESCRIPTION
The output from WinRM is a byte string and on Python 3 the Session class tries to clear up the clixml that is produced on the stderr. Currently it expects a text/unicode string which is fine on Python 2 but doesn't work on 3. This PR fixes that issue and ensure the stderr is cleaned and outputted properly as per before.

Supersedes:
* https://github.com/diyan/pywinrm/pull/112
* https://github.com/diyan/pywinrm/pull/137
* https://github.com/diyan/pywinrm/pull/178
* https://github.com/diyan/pywinrm/pull/218
* https://github.com/diyan/pywinrm/pull/220