### PR TITLE
Remove support for python 2.6 (breaks Travis CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
   include:
     # Python 3.0-3.2 does not support explicit unicode literal, see pep-0414
     # Define 'sudo: false' to run on container-based workers
-    - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=2.6.9 }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=2.7.13 }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.3.6 }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=3.4.5 }
@@ -21,7 +20,6 @@ matrix:
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=pypy2-5.6.0 }
     - { os: linux, dist: precise, sudo: false, env: UBUNTU=12.04 PYENV=pypy3.3-5.5-alpha }
 
-    - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=2.6.9 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=2.7.13 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.3.6 }
     - { os: linux, dist: trusty, sudo: false, env: UBUNTU=14.04 PYENV=3.4.5 }


### PR DESCRIPTION
Travis CI is failing because python 2.6 is no longer supported by pip
and dependencies.