### PR TITLE
Fix Python 2.6 issues in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,10 @@ install:
   - pip install virtualenv
   - python -m virtualenv ~/.venv
   - source ~/.venv/bin/activate
+  - pip install -r requirements-test.txt
   - pip install coveralls
   - pip install .[credssp]
   - pip install .[kerberos]
-  - pip install -r requirements-test.txt
 script:
   - py.test -v --pep8 --cov=winrm --cov-report=term-missing winrm/tests/
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ pytest<=3.2.5
 pytest-cov
 pytest-pep8
 mock
+pycparser<=2.18; python_version<"2.7"


### PR DESCRIPTION
Without this fix all Python 2.6 tests in Travis CI fail.