### PR TITLE
default encoding: utf-8 / error handling python 3

### DIFF
--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -57,7 +57,6 @@ class Session(object):
     def _clean_error_msg(self, msg):
         """converts a Powershell CLIXML message to a more human readable string
         """
-        # FIXME: msg should be str, not bytes. how to detect encoding?
         msg = msg.decode('utf-8')
 
         # TODO prepare unit test, beautify code

--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -59,7 +59,7 @@ class Session(object):
         """
         # TODO prepare unit test, beautify code
         # if the msg does not start with this, return it as is
-        if msg.startswith("#< CLIXML\r\n"):
+        if msg.startswith("#< CLIXML\r\n".encode()):
             # for proper xml, we need to remove the CLIXML part
             # (the first line)
             msg_xml = msg[11:]

--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -57,9 +57,12 @@ class Session(object):
     def _clean_error_msg(self, msg):
         """converts a Powershell CLIXML message to a more human readable string
         """
+        # FIXME: msg should be str, not bytes. which encoding?
+        msg = msg.decode()
+
         # TODO prepare unit test, beautify code
         # if the msg does not start with this, return it as is
-        if msg.startswith("#< CLIXML\r\n".encode()):
+        if msg.startswith("#< CLIXML\r\n"):
             # for proper xml, we need to remove the CLIXML part
             # (the first line)
             msg_xml = msg[11:]

--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -58,15 +58,6 @@ class Session(object):
     def _clean_error_msg(self, msg):
         """converts a Powershell CLIXML message to a more human readable string
         """
-        print("\n".join(map(
-            lambda l:" ".join("{:02x}".format(c) for c in l)
-            + "  " 
-            + "".join([chr(c).encode('ascii',errors='replace').decode("ascii") for c in l]), 
-            [msg[i:i+16] for i in range(0, len(msg), 16)])))
-
-        with open("debug.txt", "wb") as w:
-            w.write(msg)
-
         # TODO prepare unit test, beautify code
         # if the msg does not start with this, return it as is
         startstr = codecs.BOM_UTF8+b"#< CLIXML\r\n"


### PR DESCRIPTION
I played around a bit with the ideas of @luc-alquier in issue #111. I could not find a BOM, but everything else seams to work fine with python 3. Not yet tested with python 2.

