### PR TITLE
#255 - Fix for shell not setting all environment variables

### DIFF
--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -150,9 +150,11 @@ class Protocol(object):
         if idle_timeout:
             shell['rsp:IdleTimeOut'] = idle_timeout
         if env_vars:
-            env = shell.setdefault('rsp:Environment', {})
+            # the rsp:Variable tag needs to be list of variables so that all
+            # environment variables in the env_vars dict are set on the shell
+            env = shell.setdefault('rsp:Environment', {}).setdefault('rsp:Variable', [])
             for key, value in env_vars.items():
-                env['rsp:Variable'] = {'@Name': key, '#text': value}
+                env.append({'@Name': key, '#text': value})
 
         res = self.send_message(xmltodict.unparse(req))
 

--- a/winrm/tests/test_integration_protocol.py
+++ b/winrm/tests/test_integration_protocol.py
@@ -48,6 +48,17 @@ def test_run_command_without_arguments_and_cleanup_command(protocol_real):
     protocol_real.close_shell(shell_id)
 
 
+def test_run_command_with_env(protocol_real):
+
+    shell_id = protocol_real.open_shell(env_vars=dict(TESTENV1='hi mom', TESTENV2='another var'))
+    command_id = protocol_real.run_command(shell_id, 'echo', ['%TESTENV1%', '%TESTENV2%'])
+    std_out, std_err, status_code = protocol_real.get_command_output(shell_id, command_id)
+    assert re.search(b'hi mom another var', std_out)
+
+    protocol_real.cleanup_command(shell_id, command_id)
+    protocol_real.close_shell(shell_id)
+
+
 def test_get_command_output(protocol_real):
     shell_id = protocol_real.open_shell()
     command_id = protocol_real.run_command(shell_id, 'ipconfig', ['/all'])


### PR DESCRIPTION
Closes #255 

Properly sets all environment variables by adding them to a list.