### PR TITLE
mcassaniti's proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@ __pycache__
 *~
 
 /winrm/tests/config.json
-
-
+.pytest_cache
+venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Version 0.3.1
 - Ensure `server_cert_validation=ignore` supersedes ca_trust_path/env overrides
 - Set minimum version of requests-credssp to support Kerberos auth over CredSSP and other changes
-- Added `proxy` support where it can be defined within the application, no longer relying on environment variables.
+- Added `proxy` support where it can be defined within the application, with the ability to specify the proxy within the application
 
 ### Version 0.3.0
 - Added support for message encryption over HTTP when using NTLM/Kerberos/CredSSP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ### Version 0.3.1
 - Ensure `server_cert_validation=ignore` supersedes ca_trust_path/env overrides
 - Set minimum version of requests-credssp to support Kerberos auth over CredSSP and other changes
-- Added `proxy` support where it can be defined within the application.
-- Added a toggle for the ability to read proxy information from environment variables via `proxy_ignore_env`
+- Added `proxy` support where it can be defined within the application, no longer relying on environment variables.
 
 ### Version 0.3.0
 - Added support for message encryption over HTTP when using NTLM/Kerberos/CredSSP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ### Version 0.3.1
-- Ensure server_cert_validation=ignore supersedes ca_trust_path/env overrides
+- Ensure `server_cert_validation=ignore` supersedes ca_trust_path/env overrides
 - Set minimum version of requests-credssp to support Kerberos auth over CredSSP and other changes
+- Added `proxy` support where it can be defined within the application.
+- Added a toggle for the ability to read proxy information from environment variables via `proxy_ignore_env`
 
 ### Version 0.3.0
 - Added support for message encryption over HTTP when using NTLM/Kerberos/CredSSP

--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -12,6 +12,7 @@ from winrm.protocol import Protocol
 FEATURE_SUPPORTED_AUTHTYPES = ['basic', 'certificate', 'ntlm', 'kerberos', 'plaintext', 'ssl', 'credssp']
 FEATURE_READ_TIMEOUT = True
 FEATURE_OPERATION_TIMEOUT = True
+FEATURE_PROXY_SUPPORT = True
 
 
 class Response(object):

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -41,7 +41,6 @@ class Protocol(object):
             credssp_disable_tlsv1_2=False,
             send_cbt=True,
             proxy=None,
-            proxy_ignore_env=False,
         ):
         """
         @param string endpoint: the WinRM webservice endpoint
@@ -60,8 +59,7 @@ class Protocol(object):
         @param int operation_timeout_sec: maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. # NOQA
         @param string kerberos_hostname_override: the hostname to use for the kerberos exchange (defaults to the hostname in the endpoint URL)
         @param bool message_encryption_enabled: Will encrypt the WinRM messages if set to True and the transport auth supports message encryption (Default True).
-        @param string proxy: Specify a proxy for the WinRM connection to use. The proxy specified here takes precedence over environment varaiables.
-        @param bool proxy_ignore_env: Ignore environment variables when determining if the WinRM connection should use a proxy (default False)
+        @param string proxy: Specify a proxy for the WinRM connection to use. Provide the proxy itself, None(default) to use environment defined proxies, or False to completely disable proxies.
         """
 
         try:
@@ -95,7 +93,6 @@ class Protocol(object):
             credssp_disable_tlsv1_2=credssp_disable_tlsv1_2,
             send_cbt=send_cbt,
             proxy=proxy,
-            proxy_ignore_env=proxy_ignore_env
         )
 
         self.username = username

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -40,7 +40,7 @@ class Protocol(object):
             message_encryption='auto',
             credssp_disable_tlsv1_2=False,
             send_cbt=True,
-            proxy=None,
+            proxy='legacy_requests',
         ):
         """
         @param string endpoint: the WinRM webservice endpoint
@@ -59,7 +59,7 @@ class Protocol(object):
         @param int operation_timeout_sec: maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. # NOQA
         @param string kerberos_hostname_override: the hostname to use for the kerberos exchange (defaults to the hostname in the endpoint URL)
         @param bool message_encryption_enabled: Will encrypt the WinRM messages if set to True and the transport auth supports message encryption (Default True).
-        @param string proxy: Specify a proxy for the WinRM connection to use. Provide the proxy itself, None(default) to use environment defined proxies, or False to completely disable proxies.
+        @param string proxy: Specify a proxy for the WinRM connection to use. 'legacy_requests'(default) to use environment variables, None to disable proxies completely or the proxy URL itself.
         """
 
         try:

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -1,62 +1,107 @@
 # coding=utf-8
 import os
+import unittest
+
 from winrm.transport import Transport
 
 
-def test_build_session_cert_validate():
-    t_default = Transport(endpoint="Endpoint",
-                          server_cert_validation='validate',
-                          username='test',
-                          password='test',
-                          auth_method='basic',
-                          )
-    t_ca_override = Transport(endpoint="Endpoint",
+class TestTransport(unittest.TestCase):
+    _old_env = None
+
+    def setUp(self) -> None:
+        super(TestTransport, self).setUp()
+        self._old_env = {}
+        os.environ.pop('REQUESTS_CA_BUNDLE', None)
+        os.environ.pop('CURL_CA_BUNDLE', None)
+        os.environ.pop('HTTPS_PROXY', None)
+        os.environ.pop('HTTP_PROXY', None)
+        os.environ.pop('NO_PROXY', None)
+
+    def tearDown(self) -> None:
+        super(TestTransport, self).tearDown()
+        os.environ.pop('REQUESTS_CA_BUNDLE', None)
+        os.environ.pop('CURL_CA_BUNDLE', None)
+        os.environ.pop('HTTPS_PROXY', None)
+        os.environ.pop('HTTP_PROXY', None)
+        os.environ.pop('NO_PROXY', None)
+
+    def test_build_session_cert_validate_1(self):
+        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+
+        t_default = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              )
+        t_default.build_session()
+        self.assertEqual('path_to_REQUESTS_CA_CERT', t_default.session.verify)
+
+    def test_build_session_cert_validate_2(self):
+        os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
+
+        t_default = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              )
+        t_default.build_session()
+        self.assertEqual('path_to_CURL_CA_CERT', t_default.session.verify)
+
+    def test_build_session_cert_override_1(self):
+        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+
+        t_default = Transport(endpoint="Endpoint",
                               server_cert_validation='validate',
                               username='test',
                               password='test',
                               auth_method='basic',
                               ca_trust_path='overridepath',
                               )
-    try:
-        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
         t_default.build_session()
-        t_ca_override.build_session()
-        assert(t_default.session.verify == 'path_to_REQUESTS_CA_CERT')
-        assert(t_ca_override.session.verify == 'overridepath')
-    finally:
-        del os.environ['REQUESTS_CA_BUNDLE']
+        self.assertEqual('overridepath', t_default.session.verify)
 
-    try:
+    def test_build_session_cert_override_2(self):
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
+
+        t_default = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              ca_trust_path='overridepath',
+                              )
         t_default.build_session()
-        t_ca_override.build_session()
-        assert(t_default.session.verify == 'path_to_CURL_CA_CERT')
-        assert (t_ca_override.session.verify == 'overridepath')
-    finally:
-        del os.environ['CURL_CA_BUNDLE']
+        self.assertEqual('overridepath', t_default.session.verify)
 
+    def test_build_session_cert_ignore_1(self):
+        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+        os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
 
-def test_build_session_cert_ignore():
-    t_default = Transport(endpoint="Endpoint",
-                          server_cert_validation='ignore',
-                          username='test',
-                          password='test',
-                          auth_method='basic',
-                          )
-    t_ca_override = Transport(endpoint="Endpoint",
+        t_default = Transport(endpoint="Endpoint",
+                              server_cert_validation='ignore',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              )
+
+        t_default.build_session()
+        self.assertIs(False, t_default.session.verify)
+
+    def test_build_session_cert_ignore_2(self):
+        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+        os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
+
+        t_default = Transport(endpoint="Endpoint",
                               server_cert_validation='ignore',
                               username='test',
                               password='test',
                               auth_method='basic',
                               ca_trust_path='boguspath'
                               )
-    try:
-        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
-        os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
+
         t_default.build_session()
-        t_ca_override.build_session()
-        assert(isinstance(t_default.session.verify, bool) and not t_default.session.verify)
-        assert (isinstance(t_ca_override.session.verify, bool) and not t_ca_override.session.verify)
-    finally:
-        del os.environ['REQUESTS_CA_BUNDLE']
-        del os.environ['CURL_CA_BUNDLE']
+        self.assertIs(False, t_default.session.verify)
+
+

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -104,4 +104,55 @@ class TestTransport(unittest.TestCase):
         t_default.build_session()
         self.assertIs(False, t_default.session.verify)
 
+    def test_build_session_proxy_defined(self):
+        t_default = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              proxy='test_proxy'
+                              )
 
+        t_default.build_session()
+        self.assertEqual({'http': 'test_proxy', 'https': 'test_proxy'}, t_default.session.proxies)
+
+    def test_build_session_proxy_defined_and_env(self):
+        os.environ['HTTPS_PROXY'] = 'random_proxy'
+
+        t_default = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              proxy='test_proxy'
+                              )
+
+        t_default.build_session()
+        self.assertEqual({'http': 'test_proxy', 'https': 'test_proxy'}, t_default.session.proxies)
+
+    def test_build_session_proxy_env(self):
+        os.environ['HTTPS_PROXY'] = 'random_proxy'
+
+        t_default = Transport(endpoint="Endpoint",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              )
+
+        t_default.build_session()
+        self.assertEqual({'https': 'random_proxy'}, t_default.session.proxies)
+
+    def test_build_session_proxy_disabled(self):
+        os.environ['HTTPS_PROXY'] = 'random-proxy'
+
+        t_default = Transport(endpoint="https://example.com",
+                              server_cert_validation='validate',
+                              username='test',
+                              password='test',
+                              auth_method='basic',
+                              proxy=False
+                              )
+
+        t_default.build_session()
+        self.assertEqual({'no_proxy': '*'}, t_default.session.proxies)

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -6,20 +6,23 @@ from winrm.transport import Transport
 
 
 class TestTransport(unittest.TestCase):
+    maxDiff = 2048
     _old_env = None
 
-    def setUp(self) -> None:
+    def setUp(self):
         super(TestTransport, self).setUp()
         self._old_env = {}
         os.environ.pop('REQUESTS_CA_BUNDLE', None)
+        os.environ.pop('TRAVIS_APT_PROXY', None)
         os.environ.pop('CURL_CA_BUNDLE', None)
         os.environ.pop('HTTPS_PROXY', None)
         os.environ.pop('HTTP_PROXY', None)
         os.environ.pop('NO_PROXY', None)
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         super(TestTransport, self).tearDown()
         os.environ.pop('REQUESTS_CA_BUNDLE', None)
+        os.environ.pop('TRAVIS_APT_PROXY', None)
         os.environ.pop('CURL_CA_BUNDLE', None)
         os.environ.pop('HTTPS_PROXY', None)
         os.environ.pop('HTTP_PROXY', None)
@@ -28,7 +31,7 @@ class TestTransport(unittest.TestCase):
     def test_build_session_cert_validate_1(self):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
 
-        t_default = Transport(endpoint="Endpoint",
+        t_default = Transport(endpoint="https://example.com",
                               server_cert_validation='validate',
                               username='test',
                               password='test',
@@ -40,7 +43,7 @@ class TestTransport(unittest.TestCase):
     def test_build_session_cert_validate_2(self):
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
 
-        t_default = Transport(endpoint="Endpoint",
+        t_default = Transport(endpoint="https://example.com",
                               server_cert_validation='validate',
                               username='test',
                               password='test',
@@ -52,7 +55,7 @@ class TestTransport(unittest.TestCase):
     def test_build_session_cert_override_1(self):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
 
-        t_default = Transport(endpoint="Endpoint",
+        t_default = Transport(endpoint="https://example.com",
                               server_cert_validation='validate',
                               username='test',
                               password='test',
@@ -65,7 +68,7 @@ class TestTransport(unittest.TestCase):
     def test_build_session_cert_override_2(self):
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
 
-        t_default = Transport(endpoint="Endpoint",
+        t_default = Transport(endpoint="https://example.com",
                               server_cert_validation='validate',
                               username='test',
                               password='test',
@@ -79,7 +82,7 @@ class TestTransport(unittest.TestCase):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
 
-        t_default = Transport(endpoint="Endpoint",
+        t_default = Transport(endpoint="https://example.com",
                               server_cert_validation='ignore',
                               username='test',
                               password='test',
@@ -93,7 +96,7 @@ class TestTransport(unittest.TestCase):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
 
-        t_default = Transport(endpoint="Endpoint",
+        t_default = Transport(endpoint="https://example.com",
                               server_cert_validation='ignore',
                               username='test',
                               password='test',
@@ -105,7 +108,7 @@ class TestTransport(unittest.TestCase):
         self.assertIs(False, t_default.session.verify)
 
     def test_build_session_proxy_defined(self):
-        t_default = Transport(endpoint="Endpoint",
+        t_default = Transport(endpoint="https://example.com",
                               server_cert_validation='validate',
                               username='test',
                               password='test',
@@ -119,7 +122,7 @@ class TestTransport(unittest.TestCase):
     def test_build_session_proxy_defined_and_env(self):
         os.environ['HTTPS_PROXY'] = 'random_proxy'
 
-        t_default = Transport(endpoint="Endpoint",
+        t_default = Transport(endpoint="https://example.com",
                               server_cert_validation='validate',
                               username='test',
                               password='test',
@@ -130,28 +133,14 @@ class TestTransport(unittest.TestCase):
         t_default.build_session()
         self.assertEqual({'http': 'test_proxy', 'https': 'test_proxy'}, t_default.session.proxies)
 
-    def test_build_session_proxy_env(self):
+    def test_build_session_proxy_with_env(self):
         os.environ['HTTPS_PROXY'] = 'random_proxy'
-
-        t_default = Transport(endpoint="Endpoint",
-                              server_cert_validation='validate',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              )
-
-        t_default.build_session()
-        self.assertEqual({'https': 'random_proxy'}, t_default.session.proxies)
-
-    def test_build_session_proxy_disabled(self):
-        os.environ['HTTPS_PROXY'] = 'random-proxy'
 
         t_default = Transport(endpoint="https://example.com",
                               server_cert_validation='validate',
                               username='test',
                               password='test',
                               auth_method='basic',
-                              proxy=False
                               )
 
         t_default.build_session()

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 
-from winrm.transport import Transport
+from winrm import transport
 
 
 class TestTransport(unittest.TestCase):
@@ -18,6 +18,7 @@ class TestTransport(unittest.TestCase):
         os.environ.pop('HTTPS_PROXY', None)
         os.environ.pop('HTTP_PROXY', None)
         os.environ.pop('NO_PROXY', None)
+        transport.DISPLAYED_PROXY_WARNING = False
 
     def tearDown(self):
         super(TestTransport, self).tearDown()
@@ -31,50 +32,50 @@ class TestTransport(unittest.TestCase):
     def test_build_session_cert_validate_1(self):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
 
-        t_default = Transport(endpoint="https://example.com",
-                              server_cert_validation='validate',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              )
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        )
         t_default.build_session()
         self.assertEqual('path_to_REQUESTS_CA_CERT', t_default.session.verify)
 
     def test_build_session_cert_validate_2(self):
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
 
-        t_default = Transport(endpoint="https://example.com",
-                              server_cert_validation='validate',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              )
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        )
         t_default.build_session()
         self.assertEqual('path_to_CURL_CA_CERT', t_default.session.verify)
 
     def test_build_session_cert_override_1(self):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
 
-        t_default = Transport(endpoint="https://example.com",
-                              server_cert_validation='validate',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              ca_trust_path='overridepath',
-                              )
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        ca_trust_path='overridepath',
+                                        )
         t_default.build_session()
         self.assertEqual('overridepath', t_default.session.verify)
 
     def test_build_session_cert_override_2(self):
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
 
-        t_default = Transport(endpoint="https://example.com",
-                              server_cert_validation='validate',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              ca_trust_path='overridepath',
-                              )
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        ca_trust_path='overridepath',
+                                        )
         t_default.build_session()
         self.assertEqual('overridepath', t_default.session.verify)
 
@@ -82,12 +83,12 @@ class TestTransport(unittest.TestCase):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
 
-        t_default = Transport(endpoint="https://example.com",
-                              server_cert_validation='ignore',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              )
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='ignore',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        )
 
         t_default.build_session()
         self.assertIs(False, t_default.session.verify)
@@ -96,25 +97,40 @@ class TestTransport(unittest.TestCase):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
 
-        t_default = Transport(endpoint="https://example.com",
-                              server_cert_validation='ignore',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              ca_trust_path='boguspath'
-                              )
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='ignore',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        ca_trust_path='boguspath'
+                                        )
 
         t_default.build_session()
         self.assertIs(False, t_default.session.verify)
 
+    def test_build_session_proxy_none(self):
+        os.environ['HTTP_PROXY'] = 'random_proxy'
+        os.environ['HTTPS_PROXY'] = 'random_proxy_2'
+
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        proxy=None
+                                        )
+
+        t_default.build_session()
+        self.assertEqual({'no_proxy': '*'}, t_default.session.proxies)
+
     def test_build_session_proxy_defined(self):
-        t_default = Transport(endpoint="https://example.com",
-                              server_cert_validation='validate',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              proxy='test_proxy'
-                              )
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        proxy='test_proxy'
+                                        )
 
         t_default.build_session()
         self.assertEqual({'http': 'test_proxy', 'https': 'test_proxy'}, t_default.session.proxies)
@@ -122,26 +138,39 @@ class TestTransport(unittest.TestCase):
     def test_build_session_proxy_defined_and_env(self):
         os.environ['HTTPS_PROXY'] = 'random_proxy'
 
-        t_default = Transport(endpoint="https://example.com",
-                              server_cert_validation='validate',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              proxy='test_proxy'
-                              )
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        proxy='test_proxy'
+                                        )
 
         t_default.build_session()
         self.assertEqual({'http': 'test_proxy', 'https': 'test_proxy'}, t_default.session.proxies)
 
-    def test_build_session_proxy_with_env(self):
+    def test_build_session_proxy_with_env_https(self):
         os.environ['HTTPS_PROXY'] = 'random_proxy'
 
-        t_default = Transport(endpoint="https://example.com",
-                              server_cert_validation='validate',
-                              username='test',
-                              password='test',
-                              auth_method='basic',
-                              )
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        )
 
         t_default.build_session()
-        self.assertEqual({'no_proxy': '*'}, t_default.session.proxies)
+        self.assertEqual({'https': 'random_proxy'}, t_default.session.proxies)
+
+    def test_build_session_proxy_with_env_http(self):
+        os.environ['HTTP_PROXY'] = 'random_proxy'
+
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        )
+
+        t_default.build_session()
+        self.assertEqual({'http': 'random_proxy'}, t_default.session.proxies)

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -63,8 +63,7 @@ class Transport(object):
             credssp_auth_mechanism='auto',
             credssp_minimum_version=2,
             send_cbt=True,
-            proxy=None,
-            proxy_ignore_env=False):
+            proxy=None):
         self.endpoint = endpoint
         self.username = username
         self.password = password
@@ -83,7 +82,6 @@ class Transport(object):
         self.credssp_minimum_version = credssp_minimum_version
         self.send_cbt = send_cbt
         self.proxy = proxy
-        self.proxy_use_env = not proxy_ignore_env
 
         if self.server_cert_validation not in [None, 'validate', 'ignore']:
             raise WinRMError('invalid server_cert_validation mode: %s' % self.server_cert_validation)
@@ -130,7 +128,7 @@ class Transport(object):
         # validate credential requirements for various auth types
         if self.auth_method != 'kerberos':
             if self.auth_method == 'certificate' or (
-                            self.auth_method == 'ssl' and (self.cert_pem or self.cert_key_pem)):
+                    self.auth_method == 'ssl' and (self.cert_pem or self.cert_key_pem)):
                 if not self.cert_pem or not self.cert_key_pem:
                     raise InvalidCredentialsError("both cert_pem and cert_key_pem must be specified for cert auth")
                 if not os.path.exists(self.cert_pem):
@@ -155,16 +153,18 @@ class Transport(object):
     def build_session(self):
         session = requests.Session()
 
-        proxies = dict()
-        if self.proxy is not None:      # pragma: no cover
+        if self.proxy is None:
+            proxies = dict()
+        elif self.proxy:
             # If there was a proxy specified then use it
             proxies = {
                 'http': self.proxy,
                 'https': self.proxy
             }
+        else:
+            proxies = {'no_proxy': '*'}
 
         # Merge proxy environment variables
-        session.trust_env = self.proxy_use_env
         settings = session.merge_environment_settings(url=self.endpoint,
                       proxies=proxies, stream=None, verify=None, cert=None)
 
@@ -198,7 +198,8 @@ class Transport(object):
             )
             kerb_args = self._get_args(man_args, opt_args, HTTPKerberosAuth.__init__)
             session.auth = HTTPKerberosAuth(**kerb_args)
-            encryption_available = hasattr(session.auth, 'winrm_encryption_available') and session.auth.winrm_encryption_available
+            encryption_available = hasattr(session.auth,
+                                           'winrm_encryption_available') and session.auth.winrm_encryption_available
         elif self.auth_method in ['certificate', 'ssl']:
             if self.auth_method == 'ssl' and not self.cert_pem and not self.cert_key_pem:
                 # 'ssl' was overloaded for HTTPS with optional certificate auth,

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -128,7 +128,7 @@ class Transport(object):
         # validate credential requirements for various auth types
         if self.auth_method != 'kerberos':
             if self.auth_method == 'certificate' or (
-                    self.auth_method == 'ssl' and (self.cert_pem or self.cert_key_pem)):
+                            self.auth_method == 'ssl' and (self.cert_pem or self.cert_key_pem)):
                 if not self.cert_pem or not self.cert_key_pem:
                     raise InvalidCredentialsError("both cert_pem and cert_key_pem must be specified for cert auth")
                 if not os.path.exists(self.cert_pem):
@@ -154,15 +154,13 @@ class Transport(object):
         session = requests.Session()
 
         if self.proxy is None:
-            proxies = dict()
-        elif self.proxy:
+            proxies = {'no_proxy': '*'}
+        else:
             # If there was a proxy specified then use it
             proxies = {
                 'http': self.proxy,
                 'https': self.proxy
             }
-        else:
-            proxies = {'no_proxy': '*'}
 
         # Merge proxy environment variables
         settings = session.merge_environment_settings(url=self.endpoint,
@@ -198,8 +196,7 @@ class Transport(object):
             )
             kerb_args = self._get_args(man_args, opt_args, HTTPKerberosAuth.__init__)
             session.auth = HTTPKerberosAuth(**kerb_args)
-            encryption_available = hasattr(session.auth,
-                                           'winrm_encryption_available') and session.auth.winrm_encryption_available
+            encryption_available = hasattr(session.auth, 'winrm_encryption_available') and session.auth.winrm_encryption_available
         elif self.auth_method in ['certificate', 'ssl']:
             if self.auth_method == 'ssl' and not self.cert_pem and not self.cert_key_pem:
                 # 'ssl' was overloaded for HTTPS with optional certificate auth,


### PR DESCRIPTION
Merging #196 with the latest from master.

### From the original PR:
This patch adds support for setting the proxy via a string. It also adds support for ignoring any environment variables that may set proxies.

This patch supersedes PR #165 and PR #151, but should implement what was requested in PR #165.

Example HTTP proxy strings are http://server:port and http://user:pass@server:port. An example SOCKS5 proxy string is socks5://user:pass@server:port.