### PR TITLE
Add deprecated warnings for CA Trusts defined by Env Var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 0.3.1
 - Ensure `server_cert_validation=ignore` supersedes ca_trust_path/env overrides
+- Added deprecated warnings if CA trusts defined by environment variables are used.
 - Set minimum version of requests-credssp to support Kerberos auth over CredSSP and other changes
 - Added `proxy` support where it can be defined within the application, with the ability to specify the proxy within the application
 

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -31,7 +31,7 @@ class Protocol(object):
     def __init__(
             self, endpoint, transport='plaintext', username=None,
             password=None, realm=None, service="HTTP", keytab=None,
-            ca_trust_path=None, cert_pem=None, cert_key_pem=None,
+            ca_trust_path='legacy_requests', cert_pem=None, cert_key_pem=None,
             server_cert_validation='validate',
             kerberos_delegation=False,
             read_timeout_sec=DEFAULT_READ_TIMEOUT_SEC,
@@ -50,7 +50,7 @@ class Protocol(object):
         @param string realm: unused
         @param string service: the service name, default is HTTP
         @param string keytab: the path to a keytab file if you are using one
-        @param string ca_trust_path: Certification Authority trust path
+        @param string ca_trust_path: Certification Authority trust path. 'legacy_requests'(default) to use environment variables, None
         @param string cert_pem: client authentication certificate file path in PEM format  # NOQA
         @param string cert_key_pem: client authentication certificate key file path in PEM format  # NOQA
         @param string server_cert_validation: whether server certificate should be validated on Python versions that suppport it; one of 'validate' (default), 'ignore' #NOQA

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -51,7 +51,7 @@ class Protocol(object):
         @param string service: the service name, default is HTTP
         @param string keytab: the path to a keytab file if you are using one
         @param string ca_trust_path: Certification Authority trust path. If server_cert_validation is set to 'validate':
-                                        'legacy_requests'(default) to use environment variables that the requests library allows
+                                        'legacy_requests'(default) to use environment variables that the requests library allows, if any.
                                         None to explicitly disallow any additional CA trust path
                                         Any other value will be considered the CA trust path to use.
         @param string cert_pem: client authentication certificate file path in PEM format  # NOQA

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -50,7 +50,10 @@ class Protocol(object):
         @param string realm: unused
         @param string service: the service name, default is HTTP
         @param string keytab: the path to a keytab file if you are using one
-        @param string ca_trust_path: Certification Authority trust path. 'legacy_requests'(default) to use environment variables, None
+        @param string ca_trust_path: Certification Authority trust path. If server_cert_validation is set to 'validate':
+                                        'legacy_requests'(default) to use environment variables that the requests library allows
+                                        None to explicitly disallow any additional CA trust path
+                                        Any other value will be considered the CA trust path to use.
         @param string cert_pem: client authentication certificate file path in PEM format  # NOQA
         @param string cert_key_pem: client authentication certificate key file path in PEM format  # NOQA
         @param string server_cert_validation: whether server certificate should be validated on Python versions that suppport it; one of 'validate' (default), 'ignore' #NOQA

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -51,7 +51,7 @@ class Protocol(object):
         @param string service: the service name, default is HTTP
         @param string keytab: the path to a keytab file if you are using one
         @param string ca_trust_path: Certification Authority trust path. If server_cert_validation is set to 'validate':
-                                        'legacy_requests'(default) to use environment variables that the requests library allows, if any.
+                                        'legacy_requests'(default) to use environment variables,
                                         None to explicitly disallow any additional CA trust path
                                         Any other value will be considered the CA trust path to use.
         @param string cert_pem: client authentication certificate file path in PEM format  # NOQA

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -100,6 +100,19 @@ class TestTransport(unittest.TestCase):
         t_default.build_session()
         self.assertEqual('overridepath', t_default.session.verify)
 
+    def test_build_session_cert_override_3(self):
+        os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'
+
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        server_cert_validation='validate',
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        ca_trust_path=None,
+                                        )
+        t_default.build_session()
+        self.assertEqual(True, t_default.session.verify)
+
     def test_build_session_cert_ignore_1(self):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
         os.environ['CURL_CA_BUNDLE'] = 'path_to_CURL_CA_CERT'

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -19,6 +19,7 @@ class TestTransport(unittest.TestCase):
         os.environ.pop('HTTP_PROXY', None)
         os.environ.pop('NO_PROXY', None)
         transport.DISPLAYED_PROXY_WARNING = False
+        transport.DISPLAYED_CA_TRUST_WARNING = False
 
     def tearDown(self):
         super(TestTransport, self).tearDown()
@@ -28,6 +29,26 @@ class TestTransport(unittest.TestCase):
         os.environ.pop('HTTPS_PROXY', None)
         os.environ.pop('HTTP_PROXY', None)
         os.environ.pop('NO_PROXY', None)
+
+    def test_build_session_cert_validate_default(self):
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        )
+        t_default.build_session()
+        self.assertEqual(True, t_default.session.verify)
+
+    def test_build_session_cert_validate_default_env(self):
+        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+
+        t_default = transport.Transport(endpoint="https://example.com",
+                                        username='test',
+                                        password='test',
+                                        auth_method='basic',
+                                        )
+        t_default.build_session()
+        self.assertEqual('path_to_REQUESTS_CA_CERT', t_default.session.verify)
 
     def test_build_session_cert_validate_1(self):
         os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'


### PR DESCRIPTION
The following is to provide `DeprecationWarning` for CA trusts defined by Environment Variables, if found.

The goal is to eventually require the CA trusts to be provided explicitly. 