### PR TITLE
Updating CHANGELOG for based on PR merges so far.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Version 0.3.1
+### Version 0.4.0
 - Ensure `server_cert_validation=ignore` supersedes ca_trust_path/env overrides
 - Set minimum version of requests-credssp to support Kerberos auth over CredSSP and other changes
 - Added `proxy` support where it can be defined within the application, with the ability to specify the proxy within the application

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Ensure `server_cert_validation=ignore` supersedes ca_trust_path/env overrides
 - Set minimum version of requests-credssp to support Kerberos auth over CredSSP and other changes
 - Added `proxy` support where it can be defined within the application, with the ability to specify the proxy within the application
+- Fix for shell not setting all environment variables.
+- Fix session clixml encoding on Python 3
 
 ### Version 0.3.0
 - Added support for message encryption over HTTP when using NTLM/Kerberos/CredSSP


### PR DESCRIPTION
Updating the CHANGELOG with a couple other PRs that have been merged that directly impacts pywinrm.

Changing the version to 0.4.0 since there have been new features added so far, primarily the proxy functionality. 