### PR TITLE
Improve unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ __pycache__
 /winrm/tests/config.json
 .pytest_cache
 venv
+.tox

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ pytest==4.4.2
 pytest-cov==2.7.1
 pytest-flake8==1.0.4
 mock==3.0.5
+requests_mock==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+xmltodict
+requests>=2.9.1
+requests_ntlm>=0.3.0
+six>=1.7.0

--- a/requirements/extras/requirements-credssp.txt
+++ b/requirements/extras/requirements-credssp.txt
@@ -1,0 +1,1 @@
+requests-credssp>=1.0.0

--- a/requirements/extras/requirements-kerberos.txt
+++ b/requirements/extras/requirements-kerberos.txt
@@ -1,0 +1,2 @@
+winkerberos>=0.5.0 ; sys_platform=="win32"
+pykerberos>=1.2.1,<2.0.0 ; sys_platform!="win32"

--- a/requirements/requirements-testmin.txt
+++ b/requirements/requirements-testmin.txt
@@ -10,4 +10,4 @@ requests-credssp==1.0.0
 winkerberos==0.5.0 ; sys_platform=="win32"
 pykerberos==1.2.1 ; sys_platform!="win32"
 
--r requirements-test.txt
+-r ../requirements-test.txt

--- a/requirements/requirements-testmin.txt
+++ b/requirements/requirements-testmin.txt
@@ -1,0 +1,13 @@
+xmltodict==0.3.0
+requests==2.9.1
+requests_ntlm==0.3.0
+six==1.7.0
+
+# credssp
+requests-credssp==1.0.0
+
+# kerberos
+winkerberos==0.5.0 ; sys_platform=="win32"
+pykerberos==1.2.1 ; sys_platform!="win32"
+
+-r requirements-test.txt

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import os
+
 from setuptools import setup
 
 __version__ = '0.3.1.dev0'
@@ -11,6 +13,29 @@ try:
 except ImportError:
     long_description = ''
 
+
+def install_deps():
+    default = open('requirements/requirements.txt', 'r').readlines()
+    pkg_list = []
+    for resource in default:
+        pkg_list.append(resource.strip())
+    return pkg_list
+
+
+def install_extras():
+    extras = dict()
+    for filename in os.listdir('requirements/extras'):
+        extra_key = filename.replace('requirements-', '').replace('.txt', '')
+        extras[extra_key] = list()
+        with open(filename, 'r') as req_file:
+            for pkg_name in req_file.readlines():
+                extras[extra_key].append(pkg_name)
+    return extras
+
+
+req_deps_list = install_deps()
+extras_deps = install_extras()
+
 setup(
     name=project_name,
     version=__version__,
@@ -23,12 +48,8 @@ setup(
     license='MIT license',
     packages=('winrm', 'winrm.tests', 'winrm.vendor.requests_kerberos'),
     package_data={'winrm.tests': ['*.ps1']},
-    install_requires=['xmltodict', 'requests>=2.9.1', 'requests_ntlm>=0.3.0', 'six'],
-    extras_require={
-        'credssp': ['requests-credssp>=1.0.0'],
-        'kerberos:sys_platform=="win32"': ['winkerberos>=0.5.0'],
-        'kerberos:sys_platform!="win32"': ['pykerberos>=1.2.1,<2.0.0']
-    },
+    install_requires=req_deps_list,
+    extras_require=extras_deps,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def install_deps():
 def install_extras():
     extras = dict()
     for filename in os.listdir('requirements/extras'):
-        extra_key = filename.replace('requirements-', '').replace('.txt', '')
+        extra_key = filename.replace('requirements/extras/requirements-', '').replace('.txt', '')
         extras[extra_key] = list()
         with open(filename, 'r') as req_file:
             for pkg_name in req_file.readlines():

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ def install_deps():
 def install_extras():
     extras = dict()
     for filename in os.listdir('requirements/extras'):
-        extra_key = filename.replace('requirements/extras/requirements-', '').replace('.txt', '')
+        extra_key = filename.replace('requirements-', '').replace('.txt', '')
         extras[extra_key] = list()
-        with open(filename, 'r') as req_file:
+        with open("requirements/extras/" + filename, 'r') as req_file:
             for pkg_name in req_file.readlines():
                 extras[extra_key].append(pkg_name)
     return extras

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 def install_deps():
-    default = open('requirements/requirements.txt', 'r').readlines()
+    default = open('requirements.txt', 'r').readlines()
     pkg_list = []
     for resource in default:
         pkg_list.append(resource.strip())

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,52 @@
+[tox]
+envlist = py27,py35,py36,py37,py38,py27min,py37min,py27base,py37base
+skip_missing_interpreters = True
+skipsdist = True
+sitepackages = False
+
+[testenv]
+ignore_errors = False
+deps =
+  -r{toxinidir}/requirements/requirements-test.txt
+  -r{toxinidir}/requirements/extras/requirements-credssp.txt
+  -r{toxinidir}/requirements/extras/requirements-kerberos.txt
+  -r{toxinidir}/requirements/requirements.txt
+commands =
+  pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
+whitelist_externals = bash
+
+# Test the base install, without extras.
+[testenv:py27base]
+ignore_errors = False
+deps =
+  -r{toxinidir}/requirements/requirements-test.txt
+  -r{toxinidir}/requirements/requirements.txt
+commands =
+  pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
+whitelist_externals = bash
+
+[testenv:py37base]
+ignore_errors = False
+deps =
+  -r{toxinidir}/requirements/requirements-test.txt
+  -r{toxinidir}/requirements/requirements.txt
+commands =
+  pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
+whitelist_externals = bash
+
+# Test the minimum requirements for the packages.
+[testenv:py27min]
+ignore_errors = False
+deps =
+  -r{toxinidir}/requirements/requirements-testmin.txt
+commands =
+  pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
+whitelist_externals = bash
+
+[testenv:py37min]
+ignore_errors = False
+deps =
+  -r{toxinidir}/requirements/requirements-testmin.txt
+commands =
+  pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
+whitelist_externals = bash

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,13 @@ sitepackages = False
 [testenv]
 ignore_errors = False
 deps =
-  -r{toxinidir}/requirements/requirements-test.txt
+  -r{toxinidir}/requirements-test.txt
   -r{toxinidir}/requirements/extras/requirements-credssp.txt
   -r{toxinidir}/requirements/extras/requirements-kerberos.txt
-  -r{toxinidir}/requirements/requirements.txt
+  -r{toxinidir}/requirements.txt
+setenv =
+  PYWINRM_TEST_CREDSSP=1
+  PYWINRM_TEST_KERBEROS=1
 commands =
   pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
 whitelist_externals = bash
@@ -19,8 +22,11 @@ whitelist_externals = bash
 [testenv:py27base]
 ignore_errors = False
 deps =
-  -r{toxinidir}/requirements/requirements-test.txt
-  -r{toxinidir}/requirements/requirements.txt
+  -r{toxinidir}/requirements-test.txt
+  -r{toxinidir}/requirements.txt
+setenv =
+  PYWINRM_TEST_CREDSSP=0
+  PYWINRM_TEST_KERBEROS=0
 commands =
   pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
 whitelist_externals = bash
@@ -28,8 +34,11 @@ whitelist_externals = bash
 [testenv:py37base]
 ignore_errors = False
 deps =
-  -r{toxinidir}/requirements/requirements-test.txt
-  -r{toxinidir}/requirements/requirements.txt
+  -r{toxinidir}/requirements-test.txt
+  -r{toxinidir}/requirements.txt
+setenv =
+  PYWINRM_TEST_CREDSSP=0
+  PYWINRM_TEST_KERBEROS=0
 commands =
   pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
 whitelist_externals = bash
@@ -39,6 +48,9 @@ whitelist_externals = bash
 ignore_errors = False
 deps =
   -r{toxinidir}/requirements/requirements-testmin.txt
+setenv =
+  PYWINRM_TEST_CREDSSP=1
+  PYWINRM_TEST_KERBEROS=1
 commands =
   pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
 whitelist_externals = bash
@@ -47,6 +59,9 @@ whitelist_externals = bash
 ignore_errors = False
 deps =
   -r{toxinidir}/requirements/requirements-testmin.txt
+setenv =
+  PYWINRM_TEST_CREDSSP=1
+  PYWINRM_TEST_KERBEROS=1
 commands =
   pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
 whitelist_externals = bash

--- a/winrm/tests/base.py
+++ b/winrm/tests/base.py
@@ -1,0 +1,68 @@
+import os
+import mock
+import unittest
+import requests_mock
+
+if os.environ.get('PYWINRM_TEST_CREDSSP') == '1':
+    EXPECT_CREDSSP = True
+elif os.environ.get('PYWINRM_TEST_CREDSSP') == '0':
+    EXPECT_CREDSSP = False
+else:
+    try:
+        from requests_credssp import HttpCredSSPAuth  # NOQA
+
+        EXPECT_CREDSSP = True
+    except ImportError as ie:
+        EXPECT_CREDSSP = False
+
+if os.environ.get('PYWINRM_TEST_KERBEROS') == '1':
+    EXPECT_KERBEROS = True
+elif os.environ.get('PYWINRM_TEST_KERBEROS') == '0':
+    EXPECT_KERBEROS = False
+else:
+    try:
+        from .vendor.requests_kerberos import HTTPKerberosAuth, REQUIRED  # NOQA
+
+        EXPECT_KERBEROS = True
+    except ImportError as ie:
+        EXPECT_KERBEROS = False
+
+
+class BaseTest(unittest.TestCase):
+    maxDiff = 2048
+    _old_env = None
+
+    def setUp(self):
+        super(BaseTest, self).setUp()
+        self.mocked_request = requests_mock.Mocker()
+        self.mocked_request.start()
+        self._old_env = {}
+        os.environ.pop('REQUESTS_CA_BUNDLE', None)
+        os.environ.pop('TRAVIS_APT_PROXY', None)
+        os.environ.pop('CURL_CA_BUNDLE', None)
+        os.environ.pop('HTTPS_PROXY', None)
+        os.environ.pop('HTTP_PROXY', None)
+        os.environ.pop('NO_PROXY', None)
+
+    def tearDown(self):
+        super(BaseTest, self).tearDown()
+        os.environ.pop('REQUESTS_CA_BUNDLE', None)
+        os.environ.pop('TRAVIS_APT_PROXY', None)
+        os.environ.pop('CURL_CA_BUNDLE', None)
+        os.environ.pop('HTTPS_PROXY', None)
+        os.environ.pop('HTTP_PROXY', None)
+        os.environ.pop('NO_PROXY', None)
+        self.mocked_request.stop()
+
+    def auto_patch(self, to_patch, spec=True):
+        """
+        Allow for mocking setup within setUp and tearDown in a single method.
+
+        :param to_patch: Name of object to patch
+        :param spec: Whether mock should adhere to the spec
+        :return: The mock.Mock object.
+        """
+        patcher = mock.patch(to_patch, spec=spec)
+        patched = patcher.start()
+        self.addCleanup(patcher.stop)
+        return patched

--- a/winrm/tests/base.py
+++ b/winrm/tests/base.py
@@ -1,5 +1,4 @@
 import os
-import mock
 import unittest
 import requests_mock
 from winrm import transport
@@ -44,16 +43,3 @@ class BaseTest(unittest.TestCase):
         os.environ.pop('HTTP_PROXY', None)
         os.environ.pop('NO_PROXY', None)
         self.mocked_request.stop()
-
-    def auto_patch(self, to_patch, spec=True):
-        """
-        Allow for mocking setup within setUp and tearDown in a single method.
-
-        :param to_patch: Name of object to patch
-        :param spec: Whether mock should adhere to the spec
-        :return: The mock.Mock object.
-        """
-        patcher = mock.patch(to_patch, spec=spec)
-        patched = patcher.start()
-        self.addCleanup(patcher.stop)
-        return patched

--- a/winrm/tests/base.py
+++ b/winrm/tests/base.py
@@ -2,30 +2,21 @@ import os
 import mock
 import unittest
 import requests_mock
+from winrm import transport
 
 if os.environ.get('PYWINRM_TEST_CREDSSP') == '1':
     EXPECT_CREDSSP = True
 elif os.environ.get('PYWINRM_TEST_CREDSSP') == '0':
     EXPECT_CREDSSP = False
 else:
-    try:
-        from requests_credssp import HttpCredSSPAuth  # NOQA
-
-        EXPECT_CREDSSP = True
-    except ImportError as ie:
-        EXPECT_CREDSSP = False
+    EXPECT_CREDSSP = transport.HAVE_CREDSSP
 
 if os.environ.get('PYWINRM_TEST_KERBEROS') == '1':
     EXPECT_KERBEROS = True
 elif os.environ.get('PYWINRM_TEST_KERBEROS') == '0':
     EXPECT_KERBEROS = False
 else:
-    try:
-        from .vendor.requests_kerberos import HTTPKerberosAuth, REQUIRED  # NOQA
-
-        EXPECT_KERBEROS = True
-    except ImportError as ie:
-        EXPECT_KERBEROS = False
+    EXPECT_KERBEROS = transport.HAVE_KERBEROS
 
 
 class BaseTest(unittest.TestCase):

--- a/winrm/tests/test_protocol.py
+++ b/winrm/tests/test_protocol.py
@@ -1,6 +1,20 @@
 import pytest
+import copy
+import xmltodict
 
+from winrm.tests import base as base_test
+from winrm.tests.winrm_responses import shells as shell_responses
 from winrm.protocol import Protocol
+
+
+def convert_to_dict(ordered_dict):
+    new_dict = dict()
+    for name, value in ordered_dict.items():
+        if isinstance(value, dict):
+            new_dict[name] = convert_to_dict(value)
+        else:
+            new_dict[name] = value
+    return new_dict
 
 
 def test_open_shell_and_close_shell(protocol_fake):
@@ -71,3 +85,23 @@ def test_fail_set_operation_timeout_as_sec():
                  operation_timeout_sec='29a')
     assert str(exc.value) == "failed to parse operation_timeout_sec as int: " \
         "invalid literal for int() with base 10: '29a'"
+
+
+class TestTransportShells(base_test.BaseTest):
+
+    def test_open_shell(self):
+        self.mocked_request.post('https://example.com', text=shell_responses.OPEN_SHELL_RESPONSE)
+        server_conn = Protocol(endpoint="https://example.com",
+                               username='test',
+                               password='test',
+                               )
+        response = server_conn.open_shell()
+        self.assertEqual('5207F2DF-E6CA-4D10-8C7F-5380F01D6FDE', response)
+
+        # MessageID will be dynamic, no need to compare
+        expected_shell_request = xmltodict.parse(copy.deepcopy(shell_responses.OPEN_SHELL_REQUEST))
+        actual_shell_request = xmltodict.parse(copy.deepcopy(self.mocked_request.request_history[0].body))
+        del expected_shell_request['env:Envelope']['env:Header']['a:MessageID']
+        del actual_shell_request['env:Envelope']['env:Header']['a:MessageID']
+
+        self.assertEqual(convert_to_dict(expected_shell_request), convert_to_dict(actual_shell_request))

--- a/winrm/tests/winrm_responses/shells.py
+++ b/winrm/tests/winrm_responses/shells.py
@@ -1,0 +1,147 @@
+OPEN_SHELL_REQUEST = """
+<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"
+              xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:b="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+              xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:cfg="http://schemas.microsoft.com/wbem/wsman/1/config"
+              xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+    <env:Header>
+        <w:OperationTimeout>PT20S</w:OperationTimeout>
+        <a:To>http://windows-host:5985/wsman</a:To>
+        <w:OptionSet>
+            <w:Option Name="WINRS_NOPROFILE">FALSE</w:Option>
+            <w:Option Name="WINRS_CODEPAGE">437</w:Option>
+        </w:OptionSet>
+        <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:ResourceURI mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+        <a:Action mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/Create</a:Action>
+        <p:DataLocale mustUnderstand="false" xml:lang="en-US"></p:DataLocale>
+        <a:ReplyTo>
+            <a:Address mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+        </a:ReplyTo>
+        <a:MessageID>uuid:63acc10b-c16f-44e6-a1f8-45798c58f63d</a:MessageID>
+        <w:Locale mustUnderstand="false" xml:lang="en-US"></w:Locale>
+    </env:Header>
+    <env:Body>
+        <rsp:Shell>
+            <rsp:InputStreams>stdin</rsp:InputStreams>
+            <rsp:OutputStreams>stdout stderr</rsp:OutputStreams>
+        </rsp:Shell>
+    </env:Body>
+</env:Envelope>
+"""
+
+OPEN_SHELL_RESPONSE = """
+<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+            xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+    <s:Header>
+        <a:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/CreateResponse</a:Action>
+        <a:MessageID>uuid:BF99E0E5-4604-4FBE-A3F9-3C2251E2655E</a:MessageID>
+        <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+        <a:RelatesTo>uuid:63acc10b-c16f-44e6-a1f8-45798c58f63d</a:RelatesTo>
+    </s:Header>
+    <s:Body>
+        <x:ResourceCreated>
+            <a:Address>http://windows-host:5985/wsman</a:Address>
+            <a:ReferenceParameters>
+                <w:ResourceURI>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+                <w:SelectorSet>
+                    <w:Selector Name="ShellId">5207F2DF-E6CA-4D10-8C7F-5380F01D6FDE</w:Selector>
+                </w:SelectorSet>
+            </a:ReferenceParameters>
+        </x:ResourceCreated>
+        <rsp:Shell xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
+            <rsp:ShellId>5207F2DF-E6CA-4D10-8C7F-5380F01D6FDE</rsp:ShellId>
+            <rsp:ResourceUri>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</rsp:ResourceUri>
+            <rsp:Owner>SERVER-01\\Administrator</rsp:Owner>
+            <rsp:ClientIP>192.168.0.1</rsp:ClientIP>
+            <rsp:IdleTimeOut>PT7200.000S</rsp:IdleTimeOut>
+            <rsp:InputStreams>stdin</rsp:InputStreams>
+            <rsp:OutputStreams>stdout stderr</rsp:OutputStreams>
+            <rsp:ShellRunTime>P0DT0H0M0S</rsp:ShellRunTime>
+            <rsp:ShellInactivity>P0DT0H0M0S</rsp:ShellInactivity>
+        </rsp:Shell>
+    </s:Body>
+</s:Envelope>
+"""
+
+CLOSE_SHELL_REQUEST = """
+<?xml version="1.0" encoding="utf-8"?>
+<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"
+              xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:b="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+              xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:cfg="http://schemas.microsoft.com/wbem/wsman/1/config"
+              xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+    <env:Header>
+        <w:OperationTimeout>PT20S</w:OperationTimeout>
+        <a:To>http://windows-host:5985/wsman</a:To>
+        <w:SelectorSet>
+            <w:Selector Name="ShellId">B5235B70-E451-4378-BFB4-53C1ABACCAD2</w:Selector>
+        </w:SelectorSet>
+        <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:ResourceURI mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+        <a:Action mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete</a:Action>
+        <p:DataLocale mustUnderstand="false" xml:lang="en-US"></p:DataLocale>
+        <a:ReplyTo>
+            <a:Address mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+        </a:ReplyTo>
+        <a:MessageID>uuid:5fc69899-bbc7-4179-a7a2-f6bb62fe2860</a:MessageID>
+        <w:Locale mustUnderstand="false" xml:lang="en-US"></w:Locale>
+    </env:Header>
+    <env:Body></env:Body>
+</env:Envelope>
+"""
+
+CLOSE_SHELL_RESPONSE = """
+<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+    <s:Header>
+        <a:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/DeleteResponse</a:Action>
+        <a:MessageID>uuid:C20C16C3-D163-45B4-9821-8A11C4ED1E42</a:MessageID>
+        <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+        <a:RelatesTo>uuid:5fc69899-bbc7-4179-a7a2-f6bb62fe2860</a:RelatesTo>
+    </s:Header>
+    <s:Body></s:Body>
+</s:Envelope>
+"""
+
+# Status code: 500
+CLOSE_SHELL_RESPONSE_ALREADY_CLOSED = """
+<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing"
+            xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+            xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+    <s:Header>
+        <a:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</a:Action>
+        <a:MessageID>uuid:C0005351-7407-4B75-BE76-2A80BA45B7BF</a:MessageID>
+        <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+        <a:RelatesTo>uuid:fe945306-d7ce-4126-b168-c704bad7588c</a:RelatesTo>
+    </s:Header>
+    <s:Body>
+        <s:Fault>
+            <s:Code>
+                <s:Value>s:Sender</s:Value>
+                <s:Subcode>
+                    <s:Value>w:InvalidSelectors</s:Value>
+                </s:Subcode>
+            </s:Code>
+            <s:Reason>
+                <s:Text xml:lang="en-US">The WS-Management service cannot process the request because the request contained invalid selectors for the
+                    resource.
+                </s:Text>
+            </s:Reason>
+            <s:Detail>
+                <w:FaultDetail>http://schemas.dmtf.org/wbem/wsman/1/wsman/faultDetail/UnexpectedSelectors</w:FaultDetail>
+                <f:WSManFault xmlns:f="http://schemas.microsoft.com/wbem/wsman/1/wsmanfault" Code="2150858843" Machine="windows-host">
+                    <f:Message>The request for the Windows Remote Shell with ShellId B387C9DF-58ED-4E97-AE80-4117D8D12116 failed because the shell was not found
+                        on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct
+                        ShellId or create a new shell and retry the operation.
+                    </f:Message>
+                </f:WSManFault>
+            </s:Detail>
+        </s:Fault>
+    </s:Body>
+</s:Envelope>
+"""


### PR DESCRIPTION
A couple of things I wanted to do in this PR:

- Add tox to allow for easier local testing.
- Start using requirement files: Makes it easier for testing various version combinations in tox
- Add testing of the minimum supported versions of each library. In case changes break old versions.
- Started creating unit tests based winrm's responses with `requests_mock` library
- Started creating tests for with and without the extras.

The goal of this to be more comfortable with the winrm interaction in the long run.