### PR TITLE
Remove redundant license parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     author='Alexey Diyan',
     author_email='alexey.diyan@gmail.com',
     url='http://github.com/diyan/pywinrm/',
-    license='MIT license',
     packages=find_packages(),
     package_data={'winrm.tests': ['*.ps1']},
     install_requires=['xmltodict', 'requests>=2.9.1', 'requests_ntlm>=0.3.0', 'six'],


### PR DESCRIPTION
The [Python packaging specifications](https://packaging.python.org/specifications/core-metadata) indicate that the [`license` parameter](https://packaging.python.org/specifications/core-metadata/#license) to `setup()` should be used in one of the following cases:

* the license is not a selection from the “License” Trove classifiers
* to specify a particular version of a license which is named via the `Classifier` field
* to indicate a variation or exception to such a license

This PR removes the explicit `license` parameter since the usage for this project does not fit any of those cases and it makes it more difficult to use tools like [pip-licenses](https://pypi.org/project/pip-licenses) since it is not consistent with other projects that just have `License :: OSI Approved :: MIT License` as one of their trove classifiers.

Please note that this does _not_ change the license of the project in any way, and since this project already has a `License :: OSI Approved :: MIT License` trove classifier the `license` parameter is redundant.