### PR TITLE
Remove distutils dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### Version 0.4.2
 - Dropped Python 3.5 from support matrix as it is EOL.
+- Remove dependency on `distutils` that is deprecated in Python 3.10.
 
 ### Version 0.4.1
-- HOT FIX: Fixing an issue with `requests_kerbose` not imported correctly from the changes in `0.4.0`.
+- HOT FIX: Fixing an issue with `requests_kerberos` not imported correctly from the changes in `0.4.0`.
 
 ### Version 0.4.0
 - Ensure `server_cert_validation=ignore` supersedes ca_trust_path/env overrides

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -6,7 +6,6 @@ import requests
 import requests.auth
 import warnings
 
-from distutils.util import strtobool
 from winrm.exceptions import InvalidCredentialsError, WinRMError, WinRMTransportError
 from winrm.encryption import Encryption
 
@@ -46,6 +45,18 @@ except ImportError as ie:
     pass
 
 __all__ = ['Transport']
+
+
+def strtobool(value):
+    value = value.lower()
+    if value in ('true', 't', 'yes', 'y', 'on', '1'):
+        return True
+
+    elif value in ('false', 'f', 'no', 'n', 'off', '0'):
+        return False
+
+    else:
+        raise ValueError("Value '%s' is not a valid bool" % value)
 
 
 class UnsupportedAuthArgument(Warning):

--- a/winrm/transport.py
+++ b/winrm/transport.py
@@ -56,7 +56,7 @@ def strtobool(value):
         return False
 
     else:
-        raise ValueError("Value '%s' is not a valid bool" % value)
+        raise ValueError("invalid truth value '%s'" % value)
 
 
 class UnsupportedAuthArgument(Warning):


### PR DESCRIPTION
Removed dependency on `distutils` which is deprecated in Python 3.10 and is slated to be removed in 3.12.