### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -78,7 +78,7 @@ class Session(object):
                     new_msg += s.text.replace("_x000D__x000A_", "\n")
             except Exception as e:
                 # if any of the above fails, the msg was not true xml
-                # print a warning and return the orignal string
+                # print a warning and return the original string
                 # TODO do not print, raise user defined error instead
                 print("Warning: there was a problem converting the Powershell"
                       " error message: %s" % (e))

--- a/winrm/encryption.py
+++ b/winrm/encryption.py
@@ -92,7 +92,7 @@ class Encryption(object):
         """
         Takes in the encrypted response from the server and decrypts it
 
-        :param response: The response that needs to be decrytped
+        :param response: The response that needs to be decrypted
         :return: The unencrypted message from the server
         """
         content_type = response.headers['Content-Type']

--- a/winrm/exceptions.py
+++ b/winrm/exceptions.py
@@ -7,7 +7,7 @@ class WinRMError(Exception):
 
 
 class WinRMTransportError(Exception):
-    """WinRM errors specific to transport-level problems (unexpcted HTTP error codes, etc)"""
+    """WinRM errors specific to transport-level problems (unexpected HTTP error codes, etc)"""
 
     @property
     def protocol(self):

--- a/winrm/protocol.py
+++ b/winrm/protocol.py
@@ -56,7 +56,7 @@ class Protocol(object):
                                         Any other value will be considered the CA trust path to use.
         @param string cert_pem: client authentication certificate file path in PEM format  # NOQA
         @param string cert_key_pem: client authentication certificate key file path in PEM format  # NOQA
-        @param string server_cert_validation: whether server certificate should be validated on Python versions that suppport it; one of 'validate' (default), 'ignore' #NOQA
+        @param string server_cert_validation: whether server certificate should be validated on Python versions that support it; one of 'validate' (default), 'ignore' #NOQA
         @param bool kerberos_delegation: if True, TGT is sent to target server to allow multiple hops  # NOQA
         @param int read_timeout_sec: maximum seconds to wait before an HTTP connect/read times out (default 30). This value should be slightly higher than operation_timeout_sec, as the server can block *at least* that long. # NOQA
         @param int operation_timeout_sec: maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. # NOQA
@@ -436,9 +436,9 @@ class Protocol(object):
         @param string command_id: The command id on the remote machine.
          See #run_command
         #@return [Hash] Returns a Hash with a key :exitcode and :data.
-         Data is an Array of Hashes where the cooresponding key
+         Data is an Array of Hashes where the corresponding key
         #   is either :stdout or :stderr.  The reason it is in an Array so so
-         we can get the output in the order it ocurrs on
+         we can get the output in the order it occurs on
         #   the console.
         """
         stdout_buffer, stderr_buffer = [], []


### PR DESCRIPTION
There are small typos in:
- winrm/__init__.py
- winrm/encryption.py
- winrm/exceptions.py
- winrm/protocol.py

Fixes:
- Should read `unexpected` rather than `unexpcted`.
- Should read `support` rather than `suppport`.
- Should read `original` rather than `orignal`.
- Should read `occurs` rather than `ocurrs`.
- Should read `decrypted` rather than `decrytped`.
- Should read `corresponding` rather than `cooresponding`.

Closes #321