### PR TITLE
Fix invalid regex escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Version 0.4.3
+- Fix invalid regex escape sequences.
+
 ### Version 0.4.2
 - Dropped Python 3.5 from support matrix as it is EOL.
 - Remove dependency on `distutils` that is deprecated in Python 3.10.

--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -104,7 +104,7 @@ class Session(object):
     @staticmethod
     def _build_url(target, transport):
         match = re.match(
-            '(?i)^((?P<scheme>http[s]?)://)?(?P<host>[0-9a-z-_.]+)(:(?P<port>\d+))?(?P<path>(/)?(wsman)?)?', target)  # NOQA
+            r'(?i)^((?P<scheme>http[s]?)://)?(?P<host>[0-9a-z-_.]+)(:(?P<port>\d+))?(?P<path>(/)?(wsman)?)?', target)  # NOQA
         scheme = match.group('scheme')
         if not scheme:
             # TODO do we have anything other than HTTP/HTTPS

--- a/winrm/vendor/requests_kerberos/kerberos_.py
+++ b/winrm/vendor/requests_kerberos/kerberos_.py
@@ -98,7 +98,7 @@ def _negotiate_value(response):
     else:
         # There's no need to re-compile this EVERY time it is called. Compile
         # it once and you won't have the performance hit of the compilation.
-        regex = re.compile('(?:.*,)*\s*Negotiate\s*([^,]*),?', re.I)
+        regex = re.compile(r'(?:.*,)*\s*Negotiate\s*([^,]*),?', re.I)
         _negotiate_value.regex = regex
 
     authreq = response.headers.get('www-authenticate', None)


### PR DESCRIPTION
Since Python 3.8 a warning is issued when an invalid escape sequence is used in a string. For regex matches we want to use a raw string to avoid this problem.

Fixes https://github.com/diyan/pywinrm/issues/293