### PR TITLE
Raise warning rather than print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 0.4.3
 - Fix invalid regex escape sequences.
+- Decoding CLIXML failures for `run_ps` will create a `UserWarning` rather than printing the warning.
 
 ### Version 0.4.2
 - Dropped Python 3.5 from support matrix as it is EOL.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'
 project_name = 'pywinrm'
 
 # PyPi supports only reStructuredText, so pandoc should be installed

--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import re
 from base64 import b64encode
 import xml.etree.ElementTree as ET
+import warnings
 
 from winrm.protocol import Protocol
 
@@ -79,9 +80,9 @@ class Session(object):
             except Exception as e:
                 # if any of the above fails, the msg was not true xml
                 # print a warning and return the original string
-                # TODO do not print, raise user defined error instead
-                print("Warning: there was a problem converting the Powershell"
-                      " error message: %s" % (e))
+                warnings.warn(
+                    "There was a problem converting the Powershell error "
+                    "message: %s" % (e))
             else:
                 # if new_msg was populated, that's our error message
                 # otherwise the original error message will be used

--- a/winrm/tests/test_session.py
+++ b/winrm/tests/test_session.py
@@ -1,3 +1,5 @@
+import pytest
+
 from winrm import Session
 
 
@@ -78,3 +80,13 @@ def test_decode_clixml_no_errors():
     expected = msg
     actual = s._clean_error_msg(msg)
     assert actual == expected
+
+
+def test_decode_clixml_invalid_xml():
+    s = Session('windows-host.example.com', auth=('john.smith', 'secret'))
+    msg = b'#< CLIXML\r\n<in >dasf<?dsfij>'
+
+    with pytest.warns(UserWarning, match="There was a problem converting the Powershell error message"):
+        actual = s._clean_error_msg(msg)
+
+    assert actual == msg


### PR DESCRIPTION
This code should not be writing to stdout, instead create a `UserWarning` on CLIXML decoding failures.

Fixes https://github.com/diyan/pywinrm/issues/103