### PR TITLE
Remove inspect method for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ on:
     branches:
     - master
 
-env:
-  WINRM_USERNAME: pywinrm-test
-  WINRM_PASSWORD: Password123!
+# env:
+#   WINRM_USERNAME: pywinrm-test
+#   WINRM_PASSWORD: Password123!
 
 jobs:
   test:
@@ -58,34 +58,33 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.arch }}
 
-    - name: Remove extra modules to speed up PowerShell startup module due to slow WinRM issue
-      if: startsWith(matrix.os, 'windows')
-      shell: bash
-      run: |
-        rm -rf "/c/Program Files/WindowsPowerShell/Modules/AWSPowerShell"
-        rm -rf "/c/Program Files/WindowsPowerShell/Modules/Microsoft.Graph*"
+    # - name: Remove extra modules to speed up PowerShell startup module due to slow WinRM issue
+    #   if: startsWith(matrix.os, 'windows')
+    #   shell: bash
+    #   run: |
+    #     rm -rf "/c/Program Files/WindowsPowerShell/Modules/AWSPowerShell"
+    #     rm -rf "/c/Program Files/WindowsPowerShell/Modules/Microsoft.Graph*"
 
-    - name: set up Windows integration tests
-      if: startsWith(matrix.os, 'windows')
-      shell: pwsh
-      run: |
-        Write-Host 'Create local admin user'
-        $userParams = @{
-            Name = $env:WINRM_USERNAME
-            Password = (ConvertTo-SecureString -AsPlainText -Force -String $env:WINRM_PASSWORD)
-            AccountNeverExpires = $true
-            PasswordNeverExpires = $true
-        }
-        $null = New-LocalUser @userParams
-        Add-LocalGroupMember -Group Administrators -Member $userParams.Name
+    # - name: set up Windows integration tests
+    #   if: startsWith(matrix.os, 'windows')
+    #   shell: pwsh
+    #   run: |
+    #     Write-Host 'Create local admin user'
+    #     $userParams = @{
+    #         Name = $env:WINRM_USERNAME
+    #         Password = (ConvertTo-SecureString -AsPlainText -Force -String $env:WINRM_PASSWORD)
+    #         AccountNeverExpires = $true
+    #         PasswordNeverExpires = $true
+    #     }
+    #     $null = New-LocalUser @userParams
+    #     Add-LocalGroupMember -Group Administrators -Member $userParams.Name
 
-        Write-Host 'Setting up WinRM settings'
-        Enable-PSRemoting -Force -SkipNetworkProfileCheck
-        Enable-WSManCredSSP -Role Server -Force
-        Set-Item WSMan:\localhost\Service\Auth\Basic $true
-        Set-Item WSMan:\localhost\Service\Auth\CredSSP $true
-        Set-Item WSMan:\localhost\Service\AllowUnencrypted $true
-        Restart-Service -Name WinRM
+    #     Write-Host 'Setting up WinRM settings'
+    #     Enable-PSRemoting -Force -SkipNetworkProfileCheck
+    #     Enable-WSManCredSSP -Role Server -Force
+    #     Set-Item WSMan:\localhost\Service\Auth\Basic $true
+    #     Set-Item WSMan:\localhost\Service\Auth\CredSSP $true
+    #     Set-Item WSMan:\localhost\Service\AllowUnencrypted $true
 
     - name: set up Linux dependencies
       if: startsWith(matrix.os, 'ubuntu')
@@ -112,9 +111,9 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       run: |
         pytest -v --flake8 --cov=winrm --cov-report=term-missing winrm/tests/
-      env:
-        WINRM_TRANSPORT: basic
-        WINRM_ENDPOINT: http://localhost:5985/wsman
+      # env:
+      #   WINRM_TRANSPORT: basic
+      #   WINRM_ENDPOINT: http://localhost:5985/wsman
 
     - name: upload coverage data
       if: "!endsWith(matrix.python-version, '2.7')"  # Uses an older coverals version that doesn't support GHA
@@ -122,20 +121,20 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: run integration with NTLM
-      if: startsWith(matrix.os, 'windows')
-      run: |
-        Set-Item WSMan:\localhost\Service\AllowUnencrypted $false
-        py.test -v winrm/tests/test_integration_protocol.py winrm/tests/test_integration_session.py
-      env:
-        WINRM_TRANSPORT: ntlm
-        WINRM_ENDPOINT: http://localhost:5985/wsman
+    # - name: run integration with NTLM
+    #   if: startsWith(matrix.os, 'windows')
+    #   run: |
+    #     Set-Item WSMan:\localhost\Service\AllowUnencrypted $false
+    #     py.test -v winrm/tests/test_integration_protocol.py winrm/tests/test_integration_session.py
+    #   env:
+    #     WINRM_TRANSPORT: ntlm
+    #     WINRM_ENDPOINT: http://localhost:5985/wsman
 
-    - name: run integration with CredSSP
-      if: startsWith(matrix.os, 'windows')
-      run: |
-        Set-Item WSMan:\localhost\Service\AllowUnencrypted $false
-        py.test -v winrm/tests/test_integration_protocol.py winrm/tests/test_integration_session.py
-      env:
-        WINRM_TRANSPORT: credssp
-        WINRM_ENDPOINT: http://localhost:5985/wsman
+    # - name: run integration with CredSSP
+    #   if: startsWith(matrix.os, 'windows')
+    #   run: |
+    #     Set-Item WSMan:\localhost\Service\AllowUnencrypted $false
+    #     py.test -v winrm/tests/test_integration_protocol.py winrm/tests/test_integration_session.py
+    #   env:
+    #     WINRM_TRANSPORT: credssp
+    #     WINRM_ENDPOINT: http://localhost:5985/wsman

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         os:
         - macos-latest
         - ubuntu-latest
-        - windows-2019
+        - windows-latest
         python-version:
         - 2.7
         - 3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.arch }}
 
+    - name: Remove extra modules to speed up PowerShell startup module due to slow WinRM issue
+      if: startsWith(matrix.os, 'windows')
+      shell: bash
+      run: |
+        rm -rf "/c/Program Files/WindowsPowerShell/Modules/AWSPowerShell"
+        rm -rf "/c/Program Files/WindowsPowerShell/Modules/Microsoft.Graph*"
+
     - name: set up Windows integration tests
       if: startsWith(matrix.os, 'windows')
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,14 @@ jobs:
         os:
         - macos-latest
         - ubuntu-latest
-        - windows-latest
+        - windows-2019
         python-version:
         - 2.7
         - 3.6
         - 3.7
         - 3.8
         - 3.9
+        - '3.10'
         - pypy-2.7
         - pypy-3.7
         arch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
         Set-Item WSMan:\localhost\Service\Auth\Basic $true
         Set-Item WSMan:\localhost\Service\Auth\CredSSP $true
         Set-Item WSMan:\localhost\Service\AllowUnencrypted $true
+        Restart-Service -Name WinRM
 
     - name: set up Linux dependencies
       if: startsWith(matrix.os, 'ubuntu')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Version 0.4.3
 - Fix invalid regex escape sequences.
 - Decoding CLIXML failures for `run_ps` will create a `UserWarning` rather than printing the warning.
+- Remove usage of deprecated Python API to support Python 3.11
 
 ### Version 0.4.2
 - Dropped Python 3.5 from support matrix as it is EOL.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 # this assumes the base requirements have been satisfied via setup.py
 pytest
 pytest-cov
-pytest-flake8
+pytest-flake8==1.0.7
 mock

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,5 @@
 # this assumes the base requirements have been satisfied via setup.py
-# pin specific versions to keep things more stable over time; only pin sub-packages if necessary
-pytest==4.4.2
-pytest-cov==2.7.1
-pytest-flake8==1.0.7
-mock==3.0.5
+pytest
+pytest-cov
+pytest-flake8
+mock

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license='MIT license',
     packages=find_packages(),
     package_data={'winrm.tests': ['*.ps1']},
-    install_requires=['xmltodict', 'requests>=2.9.1', 'requests_ntlm>=0.3.0', 'six'],
+    install_requires=['xmltodict', 'requests>=2.9.1', 'requests_ntlm>=1.1.0', 'six'],
     extras_require={
         'credssp': ['requests-credssp>=1.0.0'],
         'kerberos:sys_platform=="win32"': ['winkerberos>=0.5.0'],
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Clustering',


### PR DESCRIPTION
`inspect.getargspec` was deprecated and is now removed in python 3.11. This removes the usage of this function and bumps the minimum version for `requests-ntlm` to ensure the arguments specified are valid. The version of `requests-ntlm` has been out for 5 years so so it should be safe to set as a minimum.