### PR TITLE
Bug fix for Pshell CLIXML cleanup

### DIFF
--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -62,7 +62,7 @@ class Session(object):
         """
         # TODO prepare unit test, beautify code
         # if the msg does not start with this, return it as is
-        if msg.startswith(b"#< CLIXML\r\n"):
+        if msg.startswith("#< CLIXML\r\n"):
             # for proper xml, we need to remove the CLIXML part
             # (the first line)
             msg_xml = msg[11:]


### PR DESCRIPTION
In `__init__.py/_clean_error_msg`, the `msg` argument is a string, and the Py3 string method `.startswith` needs a string, not a byte array. This throws error on remote pshell execution, tested on Win10, Windows Server 2016. This bug was introduced in the 
[jun 5,2018 commit Fix for session cli encoding on Python 3](https://github.com/diyan/pywinrm/commit/d0d2720803e8730dffbc2503898fad1e753fb36f)