### PR TITLE
Add type annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       run: |
         python -m black . --check
         python -m isort . --check-only
+        python -m mypy .
         pytest -v --cov=winrm --cov-report=term-missing winrm/tests/
 
     - name: upload coverage data

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ __pycache__
 /winrm/tests/config.json
 .pytest_cache
 venv
+.mypy_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ include-package-data = true
 packages = ["winrm"]
 
 [tool.setuptools.package-data]
+"winrm" = ["py.typed"]
 "winrm.tests" = ["*.ps1"]
 
 [tool.setuptools.dynamic]
@@ -78,3 +79,37 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+exclude = "build/|winrm/tests/|winrm/vendor/"
+mypy_path = "$MYPY_CONFIG_FILE_DIR"
+python_version = "3.8"
+show_error_codes = true
+show_column_numbers = true
+disallow_any_unimported = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_reexport = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = "winrm.vendor.*"
+follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+module = "requests.packages.urllib3.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "requests_credssp"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "requests_ntlm"
+ignore_missing_imports = true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,9 @@
 # this assumes the base requirements have been satisfied via setup.py
 black == 24.4.2
 isort == 5.13.2
+mypy == 1.10.0
 pytest
 pytest-cov
 mock
+types-requests
+types-xmltodict

--- a/winrm/exceptions.py
+++ b/winrm/exceptions.py
@@ -11,22 +11,22 @@ class WinRMTransportError(Exception):
     """WinRM errors specific to transport-level problems (unexpected HTTP error codes, etc)"""
 
     @property
-    def protocol(self):
+    def protocol(self) -> str:
         return self.args[0]
 
     @property
-    def code(self):
+    def code(self) -> int:
         return self.args[1]
 
     @property
-    def message(self):
+    def message(self) -> str:
         return "Bad HTTP response returned from server. Code {0}".format(self.code)
 
     @property
-    def response_text(self):
+    def response_text(self) -> str:
         return self.args[2]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
 


### PR DESCRIPTION
Add type annotations to the pywinrm library. This can help reduce type
related bugs inside the library and also help callers to figure out the
correct values that can be used in the public API.