### PR TITLE
Add new public APIs for header and command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Added `WSManFaultError` which contains WSManFault specific information when receiving a 500 WSMan fault response
   - This contains pre-parsed values like the code, subcode, wsman fault code, wmi error code, and raw response
   - It can be used by the caller to implement fallback behaviour based on specific error codes
+- Added public API `protocol.build_wsman_header` that can create the standard WSMan header used by the protocol
+  - This can be used to craft custom WSMan messages that are not supported in the existing actions
+- Added public API `protocol.get_command_output_raw`
+  - This can be used to send a single WSMan receive request and get the output
+  - Unlike `protocol.get_command_output`, it will not loop until the command is done and will not catch a timeout exception
 
 ### Version 0.4.3
 - Fix invalid regex escape sequences.

--- a/winrm/tests/test_protocol.py
+++ b/winrm/tests/test_protocol.py
@@ -3,17 +3,10 @@ import pytest
 from winrm.protocol import Protocol
 
 
-def test_build_wsman_header(protocol_fake):
-    actual = protocol_fake.build_wsman_header("my action", "resource uri", "shell id", "message id")
-
-    assert actual["env:Header"]["a:Action"]["#text"] == "my action"
-    assert actual["env:Header"]["w:ResourceURI"]["#text"] == "resource uri"
-    assert actual["env:Header"]["a:MessageID"] == "uuid:message id"
-    assert actual["env:Header"]["w:SelectorSet"]["w:Selector"]["#text"] == "shell id"
-
-
-def test_build_wsman_header_compat_api(protocol_fake):
-    actual = protocol_fake._get_soap_header("my action", "resource uri", "shell id", "message id")
+@pytest.mark.parametrize("func_name", ["build_wsman_header", "_get_soap_header"])
+def test_build_wsman_header(func_name, protocol_fake):
+    func = getattr(protocol_fake, func_name)
+    actual = func("my action", "resource uri", "shell id", "message id")
 
     assert actual["env:Header"]["a:Action"]["#text"] == "my action"
     assert actual["env:Header"]["w:ResourceURI"]["#text"] == "resource uri"
@@ -58,23 +51,13 @@ def test_get_command_output(protocol_fake):
     protocol_fake.close_shell(shell_id)
 
 
-def test_get_command_output_raw(protocol_fake):
+@pytest.mark.parametrize("func_name", ["get_command_output_raw", "_raw_get_command_output"])
+def test_get_command_output_raw(func_name, protocol_fake):
+    func = getattr(protocol_fake, func_name)
     shell_id = protocol_fake.open_shell()
     command_id = protocol_fake.run_command(shell_id, "ipconfig", ["/all"])
-    std_out, std_err, status_code, done = protocol_fake.get_command_output_raw(shell_id, command_id)
-    assert status_code == 0
-    assert b"Windows IP Configuration" in std_out
-    assert len(std_err) == 0
-    assert done is True
 
-    protocol_fake.cleanup_command(shell_id, command_id)
-    protocol_fake.close_shell(shell_id)
-
-
-def test_get_command_output_raw_compat_api(protocol_fake):
-    shell_id = protocol_fake.open_shell()
-    command_id = protocol_fake.run_command(shell_id, "ipconfig", ["/all"])
-    std_out, std_err, status_code, done = protocol_fake._raw_get_command_output(shell_id, command_id)
+    std_out, std_err, status_code, done = func(shell_id, command_id)
     assert status_code == 0
     assert b"Windows IP Configuration" in std_out
     assert len(std_err) == 0


### PR DESCRIPTION
Adds new APIs on the protocol class to expose a publicly supported way to build the WSMan SOAP headers used internally and to get a single output value. The original methods have been kept around for backwards compatibility as while they were not set as public they have been used in various libraries so removing them now will cause breakages.