### PR TITLE
drop dependency on old external mock module

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,5 @@ isort == 5.13.2
 mypy == 1.10.0
 pytest
 pytest-cov
-mock
 types-requests
 types-xmltodict

--- a/winrm/tests/conftest.py
+++ b/winrm/tests/conftest.py
@@ -1,9 +1,9 @@
 # flake8: noqa
 import os
 import uuid
+from unittest.mock import patch
 
 import xmltodict
-from mock import patch
 from pytest import fixture, skip
 
 open_shell_request = """\

--- a/winrm/tests/test_transport.py
+++ b/winrm/tests/test_transport.py
@@ -1,8 +1,7 @@
 # coding=utf-8
 import os
 import unittest
-
-import mock
+from unittest import mock
 
 from winrm import transport
 from winrm.exceptions import InvalidCredentialsError, WinRMError


### PR DESCRIPTION
Hi,

As only Py3.8+ is supported, usage of old external mock does not makes sense anymore (It is stuck forever at the snapshot of stdlib from Py3.6)  #345 

Greetings

---

https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.